### PR TITLE
Additional args for Alert\run() callback

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -181,11 +181,21 @@ function tick() {
  * Start the event reactor and assume program flow control
  *
  * @param callable $onStart Optional callback to invoke immediately upon reactor start
+ * @param array $args Additional arguments to pass to the $onStart callback
  * @return void
  */
-function run(callable $onStart = null) {
+function run(callable $onStart = null, array $args = []) {
     static $reactor;
     $reactor = $reactor ?: ReactorFactory::select();
+
+    if ($onStart && $args) {
+        $wrappedOnStart = function($reactor) use($onStart, $args) {
+            array_unshift($args, $reactor);
+            call_user_func_array($onStart, $args);
+        };
+        $onStart = $wrappedOnStart;
+    }
+
     $reactor->run($onStart);
 }
 


### PR DESCRIPTION
Because this can be useful to avoid unnecessary constructors/properties solely for DI when the application entry point is an object method.

Consider:

``` php
class App
{
    private $data;
    public function __construct($data)
    {
        $this->data = $data;
    }
    public function run($reactor)
    {
        // do stuff with $this->data
    }
}

$app = new App(new Thing);
Alert\run([$app, 'run']);
```

vs.

``` php
class App
{
    public function run($reactor, $data)
    {
        // do stuff with $data
    }
}

$app = new App;
Alert\run([$app, 'run'], [new Thing]);
```
