### PR TITLE
Don't stop when there are immediates left in NativeReactor

### DIFF
--- a/lib/NativeReactor.php
+++ b/lib/NativeReactor.php
@@ -111,7 +111,7 @@ class NativeReactor implements Reactor {
 
         if ($this->readStreams || $this->writeStreams) {
             $this->selectActionableStreams($timeToNextAlarm);
-        } elseif (!$this->alarmOrder) {
+        } elseif ((!($this->alarmOrder) || !$this->immediates)) {
             $this->stop();
         } elseif ($timeToNextAlarm > 0) {
             usleep($timeToNextAlarm * self::$MICROSECOND);


### PR DESCRIPTION
I can't seem to come up with a simple reproducer for this, but I managed to end up in a situation where there was only a single immediate scheduled, the reactor stopped itself because it did not appear in alarmOrder, and that immediate then scheduled a stream watcher, but the reactor was stopped so it was ignored.

I really wish I could make a reproducer for this, but I can't. All I know is that this fixes it.

 Sorry.
