### PR TITLE
Throws a RuntimeException if php-uv or libevent is not loaded.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,10 @@
             "dev-master": "1.0.x-dev"
         }
     },
+    "suggest": {
+      "php-uv": "Extension for libuv backends (high performance use cases).",
+      "pecl/libevent": "Extension for libevent backends (high performance use cases)."
+    },
     "repositories": [
         {
             "type": "vcs",

--- a/lib/LibeventReactor.php
+++ b/lib/LibeventReactor.php
@@ -22,6 +22,10 @@ class LibeventReactor implements SignalReactor {
     private static $instanceCount = 0;
 
     public function __construct() {
+        if (!extension_loaded('libevent')) {
+            throw new \RuntimeException('The pecl-libevent extension is required to use the LibeventReactor.');
+        }
+
         $this->base = event_base_new();
         $this->gcEvent = event_new();
         event_timer_set($this->gcEvent, [$this, 'collectGarbage']);

--- a/lib/UvReactor.php
+++ b/lib/UvReactor.php
@@ -25,6 +25,10 @@ class UvReactor implements SignalReactor {
     private static $instanceCount = 0;
 
     public function __construct() {
+        if (!extension_loaded('uv')) {
+            throw new \RuntimeException('The php-uv extension is required to use the UvReactor.');
+        }
+
         $this->loop = uv_loop_new();
         $this->gcWatcher = uv_timer_init($this->loop);
         $this->gcCallback = function() { $this->collectGarbage(); };


### PR DESCRIPTION
Using UvReactor or LibeventReactor directly (instead of Amp\getReactor)
doesn't check if php-uv/libevent is loaded and dies with a 'Call to undefined
function' message.