### PR TITLE
Fix waiting for immediates resolution

### DIFF
--- a/lib/LibeventReactor.php
+++ b/lib/LibeventReactor.php
@@ -66,7 +66,7 @@ class LibeventReactor implements SignalReactor {
             if (empty($this->enabledWatcherCount)) {
                 break;
             }
-            event_base_loop($this->base, EVLOOP_ONCE);
+            event_base_loop($this->base, EVLOOP_ONCE | (empty($this->immediates) ? 0 : EVLOOP_NONBLOCK));
         }
 
         if ($this->stopException) {
@@ -116,7 +116,7 @@ class LibeventReactor implements SignalReactor {
         $this->isRunning = true;
 
         if (empty($this->immediates) || $this->doImmediates()) {
-            $flags = $noWait ? (EVLOOP_ONCE | EVLOOP_NONBLOCK) : EVLOOP_ONCE;
+            $flags = $noWait || !empty($this->immediates) ? (EVLOOP_ONCE | EVLOOP_NONBLOCK) : EVLOOP_ONCE;
             event_base_loop($this->base, $flags);
         }
 

--- a/lib/UvReactor.php
+++ b/lib/UvReactor.php
@@ -74,7 +74,7 @@ class UvReactor implements SignalReactor {
             if (empty($this->enabledWatcherCount)) {
                 break;
             }
-            uv_run($this->loop, \UV::RUN_DEFAULT | \UV::RUN_ONCE);
+            uv_run($this->loop, \UV::RUN_DEFAULT | (empty($this->immediates) ? \UV::RUN_ONCE : \UV::RUN_NOWAIT));
         }
 
         if ($this->stopException) {
@@ -124,7 +124,7 @@ class UvReactor implements SignalReactor {
         $this->isRunning = true;
 
         if (empty($this->immediates) || $this->doImmediates()) {
-            $flags = $noWait ? (\UV::RUN_NOWAIT | \UV::RUN_ONCE) : \UV::RUN_ONCE;
+            $flags = $noWait || !empty($this->immediates) ? (\UV::RUN_NOWAIT | \UV::RUN_ONCE) : \UV::RUN_ONCE;
             uv_run($this->loop, $flags);
         }
 


### PR DESCRIPTION
If there are immediates generated in immediates, they have to wait until next tick - which may only be triggered in far future or never, depending on if there are other read/writeWatchers or timers…

That means we can sometimes get very weird blocking situations...