### PR TITLE
drop $forceNew param in getReactor()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### master
 
-- n/a
+> **BC BREAKS:**
+
+- Dropped `\Amp\getReactor` param `$forceNew` as it doesn't has a proper use case.
 
 v0.16.0
 -------

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -8,12 +8,10 @@ namespace Amp;
  * @param bool $forceNew If true return a new Reactor instance (but don't store it for future use)
  * @return Reactor
  */
-function getReactor($forceNew = false) {
+function getReactor() {
     static $reactor;
 
-    if ($forceNew) {
-        return chooseReactor();
-    } elseif ($reactor) {
+    if ($reactor) {
         return $reactor;
     } else {
         return $reactor = chooseReactor();


### PR DESCRIPTION
At runtime there are no use cases where one would like to re-create the reactor. only multi instance scenario is unit tests, but those don't need to be covered in the public api.