### PR TITLE
Add reactor bound state

### DIFF
--- a/lib/Reactor.php
+++ b/lib/Reactor.php
@@ -158,4 +158,6 @@ interface Reactor {
      * @return array
      */
     public function info();
+    
+    /* MUST NOT IMPLEMENT __set() */
 }

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -37,6 +37,27 @@ function driver() {
 }
 
 /**
+ * Get reactor bound state by identifier
+ *
+ * @param string $key identifier for state
+ */
+function getState($key) {
+    $reactor = reactor();
+    return isset($reactor->__dynamicState[$key]) ? $reactor->__dynamicState[$key] : null;
+}
+
+/**
+ * Set reactor bound state by identifier to a value
+ *
+ * @param string $key identifier for state
+ * @param $value
+ * @return void
+ */
+function setState($key, $value) {
+    reactor()->__dynamicState[$key] = $value;
+}
+
+/**
  * Start the event reactor and assume program flow control
  *
  * @param callable $onStart An optional callback to invoke immediately when the Reactor starts


### PR DESCRIPTION
It is common to have code like:

https://github.com/amphp/aerys/blob/77994f6319b8b6b8289cf9637e7747bca41257f9/lib/WorkerProcess.php#L23-L29

Or in tests:
https://github.com/amphp/aerys/blob/77994f6319b8b6b8289cf9637e7747bca41257f9/test/ServerTest.php#L408-L410

It is easy to miss reseting or backing up some dependency when swapping reactors and leads to hard to debug bugs. This PR tries to fix that.

Now dependents can just use `$state = \Amp\getState("amp.dns");` or `$filesystem = \Amp\getState("amp.file");`.

In general, I think the single responsibility of the Reactor is managing events, not providing storage; for that reason (and because a new method in the interface would be a major BC break and require a v2 … E_DEPENDENCY_HELL) I'm proposing the implementation the way it is, with a dynamic property.

@rdlowrey @kelunik feedback please :-)