### PR TITLE
Make resolve() accept also callables

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -752,9 +752,20 @@ function coroutine(callable $func) {
  * Upon resolution the Generator return value is used to succeed the promised result. If an
  * error occurs during coroutine resolution the returned promise fails.
  *
- * @param \Generator $generator The generator to resolve as a coroutine
+ * @param \Generator|callable $generator A generator or callable the returns a generator to resolve as a coroutine
+ * @return \Amp\Promise
  */
-function resolve(\Generator $generator) {
+function resolve($generator) {
+    if (!$generator instanceof \Generator) {
+        if (is_callable($generator)) {
+            $generator = call_user_func($generator);
+        }
+
+        if (!$generator instanceof \Generator) {
+            throw new \LogicException('Callable passed to resolve() did not return an instance of Generator');
+        }
+    }
+
     $cs = new CoroutineState;
     $cs->promisor = new Deferred;
     $cs->generator = $generator;


### PR DESCRIPTION
This is just syntactic sugar around `resolve()` for use with a generator closure to avoid temporary variables.

Instead of having to write:

```php
$var = function() {
    yield;
};
return resolve($var);
```

you can simply write:

```php
return promise(function() {
    yield;
});
```

I'm not married to the function name if it doesn't suit, but this is an option I have found frustratingly missing.

This PR also adds a missing `@return` tag to the `resolve()` docblock.