### PR TITLE
Make exception messages more generic

### DIFF
--- a/lib/MultiReasonException.php
+++ b/lib/MultiReasonException.php
@@ -11,7 +11,7 @@ class MultiReasonException extends \Exception {
      * @param string|null $message
      */
     public function __construct(array $reasons, string $message = null) {
-        parent::__construct($message ?: "Too many promises were rejected");
+        parent::__construct($message ?: "Multiple errors encountered");
 
         $this->reasons = $reasons;
     }

--- a/lib/TimeoutException.php
+++ b/lib/TimeoutException.php
@@ -7,6 +7,6 @@ class TimeoutException extends \Exception {
      * @param string|null $message
      */
     public function __construct(string $message = null) {
-        parent::__construct($message ?: "Promise resolution timed out");
+        parent::__construct($message ?: "Operation timed out");
     }
 }


### PR DESCRIPTION
Since the exceptions don't have to be specifically tied to promise resolution I believe it makes more sense to make the default messages more generic.