### PR TITLE
Add final where it's missing

### DIFF
--- a/lib/InvalidYieldError.php
+++ b/lib/InvalidYieldError.php
@@ -2,7 +2,7 @@
 
 namespace Amp;
 
-class InvalidYieldError extends \Error {
+final class InvalidYieldError extends \Error {
     /**
      * @param \Generator $generator
      * @param string $prefix

--- a/lib/LazyPromise.php
+++ b/lib/LazyPromise.php
@@ -9,7 +9,7 @@ use AsyncInterop\Promise;
  * the promise). $promisor can return a promise or any value. If $promisor throws an exception, the promise fails with
  * that exception.
  */
-class LazyPromise implements Promise {
+final class LazyPromise implements Promise {
     /** @var callable|null */
     private $promisor;
 

--- a/lib/Listener.php
+++ b/lib/Listener.php
@@ -14,7 +14,7 @@ use AsyncInterop\Promise;
  * }
  * $result = $listener->getResult();
  */
-class Listener {
+final class Listener {
     /** @var \Amp\Stream */
     private $stream;
 

--- a/lib/MultiReasonException.php
+++ b/lib/MultiReasonException.php
@@ -2,7 +2,7 @@
 
 namespace Amp;
 
-class MultiReasonException extends \Exception {
+final class MultiReasonException extends \Exception {
     /** @var \Throwable[] */
     private $reasons;
 

--- a/lib/TimeoutException.php
+++ b/lib/TimeoutException.php
@@ -2,7 +2,7 @@
 
 namespace Amp;
 
-class TimeoutException extends \Exception {
+final class TimeoutException extends \Exception {
     /**
      * @param string|null $message
      */


### PR DESCRIPTION
We can always remove them later if someone really needs to extend one of the exception classes.

Maybe we should have an interface for Listener?