### PR TITLE
Implement IteratorTransform to allow fluent transformation

### DIFF
--- a/lib/IteratorTransform.php
+++ b/lib/IteratorTransform.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Amp;
+
+/**
+ * Allows consecutive transformation of an iterator.
+ */
+class IteratorTransform implements Iterator {
+    private $applied = false;
+    private $iterator;
+
+    public function __construct(Iterator $iterator) {
+        $this->iterator = $iterator;
+    }
+
+    /**
+     * Applies a stream transformation.
+     *
+     * The given callback will be called with the iterator as first and an emit callable as second parameter. Generators
+     * will automatically be run as coroutine. Return values are ignored.
+     *
+     * @param callable $callback
+     *
+     * @return IteratorTransform
+     */
+    public function apply(callable $callback): self {
+        $this->applied = true;
+
+        return new self(new Producer(function (callable $emit) use ($callback) {
+            if (false) {
+                // ensure it's a generator
+                yield;
+            }
+
+            $return = $callback($this->iterator, $emit);
+
+            if ($return instanceof \Generator) {
+                yield from $return;
+            }
+        }));
+    }
+
+    /** @inheritdoc */
+    public function advance(): Promise {
+        if ($this->applied) {
+            return new Success(false);
+        }
+
+        return $this->iterator->advance();
+    }
+
+    /** @inheritdoc */
+    public function getCurrent() {
+        if ($this->applied) {
+            throw new \Error("IteratorTransform::apply() as already been called and the iterator been emptied.");
+        }
+
+        return $this->iterator->getCurrent();
+    }
+}

--- a/test/IteratorTransformTest.php
+++ b/test/IteratorTransformTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Amp\Test;
+
+use Amp\Iterator;
+use Amp\IteratorTransform;
+use Amp\Loop;
+use PHPUnit\Framework\TestCase;
+use function Amp\Iterator\fromIterable;
+
+class IteratorTransformTest extends TestCase {
+    public function testCanFilter() {
+        // Test that it applies backpressure
+        $this->expectOutputString("0010101");
+
+        $iterator = fromIterable(\range(0, 3));
+        $count = 0;
+
+        $iteratorTransform = new IteratorTransform($iterator);
+        $iteratorTransform->apply(function (Iterator $iterator, $emit) {
+            while (yield $iterator->advance()) {
+                print "0";
+
+                if ($iterator->getCurrent()) {
+                    yield $emit($iterator->getCurrent());
+                }
+            }
+        })->apply(function (Iterator $iterator) use (&$count) {
+            while (yield $iterator->advance()) {
+                print "1";
+
+                $count++;
+            }
+        });
+
+        $this->assertSame(3, $count);
+    }
+
+    public function testIsEmptyAfterApply() {
+        Loop::run(function () {
+            $iterator = fromIterable(\range(0, 3), 100);
+
+            $iteratorTransform = new IteratorTransform($iterator);
+            $iteratorTransform->apply(function (Iterator $iterator, $emit) {
+                while (yield $iterator->advance());
+            });
+
+            $this->assertFalse(yield $iteratorTransform->advance());
+
+            $this->expectException(\Error::class);
+            $iteratorTransform->getCurrent();
+        });
+    }
+}


### PR DESCRIPTION
This allows chaining transformations. Closes #109.

I'm not really sure we need something like that.

/cc @joshdifabio 