### PR TITLE
Support yielding promise => cancellation-token in coroutines

### DIFF
--- a/lib/Coroutine.php
+++ b/lib/Coroutine.php
@@ -119,7 +119,21 @@ final class Coroutine implements Promise {
                 $promise = $this->generator->key();
 
                 if (!$promise instanceof Promise) {
-                    throw new \Error("Must yield a promise as the key when yielding a cancellation token");
+                    if (\is_array($promise)) {
+                        $promise = Promise\all($promise);
+                    } elseif ($promise instanceof ReactPromise) {
+                        $promise = Promise\adapt($promise);
+                    } else {
+                        return new Failure(new InvalidYieldError(
+                            $this->generator,
+                            \sprintf(
+                                "Key must be an instance of %s or %s or array of such instances when yielding an instance of %s",
+                                Promise::class,
+                                ReactPromise::class,
+                                CancellationToken::class
+                            )
+                        ));
+                    }
                 }
 
                 return Promise\cancellable($promise, $yielded);

--- a/lib/Coroutine.php
+++ b/lib/Coroutine.php
@@ -115,6 +115,16 @@ final class Coroutine implements Promise {
                 return Promise\adapt($yielded);
             }
 
+            if ($yielded instanceof CancellationToken) {
+                $promise = $this->generator->key();
+
+                if (!$promise instanceof Promise) {
+                    throw new \Error("Must yield a promise as the key when yielding a cancellation token");
+                }
+
+                return Promise\cancellable($promise, $yielded);
+            }
+
             // No match, continue to returning Failure below.
         } catch (\Throwable $exception) {
             // Conversion to promise failed, fall-through to returning Failure below.


### PR DESCRIPTION
This PR uses the `key => value` generator syntax to support yielding a cancellation token with a promise as a convenient way of providing an escape to yielding promises that slowly or never resolve.