### PR TITLE
Ignore only warnings for interrupted syscalls in NativeDriver

### DIFF
--- a/lib/Loop/NativeDriver.php
+++ b/lib/Loop/NativeDriver.php
@@ -144,7 +144,13 @@ class NativeDriver extends Driver {
 
             // Error reporting suppressed since stream_select() emits an E_WARNING if it is interrupted by a signal.
             if (!@\stream_select($read, $write, $except, $seconds, $microseconds)) {
-                return;
+                $error = error_get_last();
+
+                if (\strpos($error["message"], "Interrupted system call") !== false) {
+                    return;
+                }
+
+                $this->error(new \Exception("stream_select() failed: " . $error["message"]));
             }
 
             foreach ($read as $stream) {

--- a/lib/Loop/NativeDriver.php
+++ b/lib/Loop/NativeDriver.php
@@ -143,14 +143,18 @@ class NativeDriver extends Driver {
             $except = null;
 
             // Error reporting suppressed since stream_select() emits an E_WARNING if it is interrupted by a signal.
-            if (!@\stream_select($read, $write, $except, $seconds, $microseconds)) {
-                $error = error_get_last();
-
-                if (\strpos($error["message"], "Interrupted system call") !== false) {
+            if (!($result = @\stream_select($read, $write, $except, $seconds, $microseconds))) {
+                if ($result === 0) {
                     return;
                 }
 
-                $this->error(new \Exception("stream_select() failed: " . $error["message"]));
+                $error = error_get_last();
+
+                if (\strpos($error["message"], "unable to select") !== 0) {
+                    return;
+                }
+
+                $this->error(new \Exception($error["message"]));
             }
 
             foreach ($read as $stream) {


### PR DESCRIPTION
Fixes #160.