### PR TITLE
Change getProtocol => getProtocolVersion

### DIFF
--- a/docs/promises/combinators.md
+++ b/docs/promises/combinators.md
@@ -43,7 +43,7 @@ Loop::run(function () {
             printf(
                 "%s | HTTP/%s %d %s\n",
                 $key,
-                $response->getProtocol(),
+                $response->getProtocolVersion(),
                 $response->getStatus(),
                 $response->getReason()
             );


### PR DESCRIPTION
In current("^3.0") amphp/artax version, there is no getProtocol method, instead of getProtocolVersion method exists in artax response. If you try, you will see kind of this error: 

"Error: Call to undefined method class@anonymous::getProtocol() in foobar.php on line xxx"
