### PR TITLE
Defined the @class docblock property

### DIFF
--- a/lib/Deferred.php
+++ b/lib/Deferred.php
@@ -2,7 +2,10 @@
 
 namespace Amp;
 
-// @codeCoverageIgnoreStart
+/**
+ * @codeCoverageIgnoreStart
+ * @class Deferred
+ */
 try {
     if (!@\assert(false)) {
         development: // PHP 7 development (zend.assertions=1)

--- a/lib/Emitter.php
+++ b/lib/Emitter.php
@@ -2,7 +2,10 @@
 
 namespace Amp;
 
-// @codeCoverageIgnoreStart
+/**
+ * @codeCoverageIgnoreStart
+ * @class Emitter
+ */
 try {
     if (!@\assert(false)) {
         development: // PHP 7 development (zend.assertions=1)


### PR DESCRIPTION
Defining the @class property in the initial doc block should allow this to be picked up in PHPStorm's auto-complete.

Tested by setting $def = new Def... and allowing PHPStorm to suggest Amp\Deferred

Tested by setting $emit = new Emit... and allowing PHPStorm to suggest Amp\Emitter