### PR TITLE
Use env or const instead of assertions to enable/disable optimizations

### DIFF
--- a/lib/Deferred.php
+++ b/lib/Deferred.php
@@ -9,7 +9,7 @@ if ((function () {
     }
     return $env === "0" || $env === "false";
 })()) {
-    development: // PHP 7 development (zend.assertions=1)
+    development: // PHP 7 development
     /**
      * Deferred is a container for a promise that is resolved using the resolve() and fail() methods of this object.
      * The contained promise may be accessed using the promise() method. This object should not be part of a public
@@ -62,7 +62,7 @@ if ((function () {
         }
     }
 } else {
-    production: // PHP 7 production environment (zend.assertions=0)
+    production: // PHP 7 production environment
     /**
      * An optimized version of Deferred for production environments that is itself the promise. Eval is used to
      * prevent IDEs and other tools from reporting multiple definitions.

--- a/lib/Deferred.php
+++ b/lib/Deferred.php
@@ -3,72 +3,73 @@
 namespace Amp;
 
 // @codeCoverageIgnoreStart
-try {
-    if (!@\assert(false)) {
-        development: // PHP 7 development (zend.assertions=1)
-        /**
-         * Deferred is a container for a promise that is resolved using the resolve() and fail() methods of this object.
-         * The contained promise may be accessed using the promise() method. This object should not be part of a public
-         * API, but used internally to create and resolve a promise.
-         */
-        final class Deferred {
-            /** @var \Amp\Promise */
-            private $promise;
-
-            /** @var callable */
-            private $resolve;
-
-            /** @var callable */
-            private $fail;
-
-            public function __construct() {
-                $this->promise = new class($this->resolve, $this->fail) implements Promise {
-                    use CallableMaker, Internal\Placeholder;
-
-                    public function __construct(&$resolve, &$fail) {
-                        $resolve = $this->callableFromInstanceMethod("resolve");
-                        $fail = $this->callableFromInstanceMethod("fail");
-                    }
-                };
-            }
-
-            /**
-             * @return \Amp\Promise
-             */
-            public function promise(): Promise {
-                return $this->promise;
-            }
-
-            /**
-             * Fulfill the promise with the given value.
-             *
-             * @param mixed $value
-             */
-            public function resolve($value = null) {
-                ($this->resolve)($value);
-            }
-
-            /**
-             * Fails the promise the the given reason.
-             *
-             * @param \Throwable $reason
-             */
-            public function fail(\Throwable $reason) {
-                ($this->fail)($reason);
-            }
-        }
-    } else {
-        production: // PHP 7 production environment (zend.assertions=0)
-        /**
-         * An optimized version of Deferred for production environments that is itself the promise. Eval is used to
-         * prevent IDEs and other tools from reporting multiple definitions.
-         */
-        eval('namespace Amp;
-        final class Deferred implements Promise {
-            use Internal\Placeholder { resolve as public; fail as public; }
-            public function promise(): Promise { return $this; }
-        }');
+if ((function () {
+    if (($env = \getenv("AMP_OPTIMIZATIONS")) === false) {
+        return !(\defined("AMP_OPTIMIZATIONS") && \AMP_OPTIMIZATIONS);
     }
-} catch (\AssertionError $exception) {
-    goto development; // zend.assertions=1 and assert.exception=1, use development definition.
+    return $env === "0" || $env === "false";
+})()) {
+    development: // PHP 7 development (zend.assertions=1)
+    /**
+     * Deferred is a container for a promise that is resolved using the resolve() and fail() methods of this object.
+     * The contained promise may be accessed using the promise() method. This object should not be part of a public
+     * API, but used internally to create and resolve a promise.
+     */
+    final class Deferred {
+        /** @var \Amp\Promise */
+        private $promise;
+
+        /** @var callable */
+        private $resolve;
+
+        /** @var callable */
+        private $fail;
+
+        public function __construct() {
+            $this->promise = new class($this->resolve, $this->fail) implements Promise {
+                use CallableMaker, Internal\Placeholder;
+
+                public function __construct(&$resolve, &$fail) {
+                    $resolve = $this->callableFromInstanceMethod("resolve");
+                    $fail = $this->callableFromInstanceMethod("fail");
+                }
+            };
+        }
+
+        /**
+         * @return \Amp\Promise
+         */
+        public function promise(): Promise {
+            return $this->promise;
+        }
+
+        /**
+         * Fulfill the promise with the given value.
+         *
+         * @param mixed $value
+         */
+        public function resolve($value = null) {
+            ($this->resolve)($value);
+        }
+
+        /**
+         * Fails the promise the the given reason.
+         *
+         * @param \Throwable $reason
+         */
+        public function fail(\Throwable $reason) {
+            ($this->fail)($reason);
+        }
+    }
+} else {
+    production: // PHP 7 production environment (zend.assertions=0)
+    /**
+     * An optimized version of Deferred for production environments that is itself the promise. Eval is used to
+     * prevent IDEs and other tools from reporting multiple definitions.
+     */
+    eval('namespace Amp;
+    final class Deferred implements Promise {
+        use Internal\Placeholder { resolve as public; fail as public; }
+        public function promise(): Promise { return $this; }
+    }');
 } // @codeCoverageIgnoreEnd

--- a/lib/Emitter.php
+++ b/lib/Emitter.php
@@ -9,9 +9,9 @@ if ((function () {
     }
     return $env === "0" || $env === "false";
 })()) {
-    development: // PHP 7 development (zend.assertions=1)
+    development: // PHP 7 development
     /**
-     * Deferred is a container for an iterator that can emit values using the emit() method and completed using the
+     * Emitter is a container for an iterator that can emit values using the emit() method and completed using the
      * complete() and fail() methods of this object. The contained iterator may be accessed using the iterate()
      * method. This object should not be part of a public API, but used internally to create and emit values to an
      * iterator.
@@ -76,7 +76,7 @@ if ((function () {
         }
     }
 } else {
-    production: // PHP 7 production environment (zend.assertions=0)
+    production: // PHP 7 production environment
     /**
      * An optimized version of Emitter for production environments that is itself the iterator. Eval is used to
      * prevent IDEs and other tools from reporting multiple definitions.

--- a/lib/Emitter.php
+++ b/lib/Emitter.php
@@ -3,86 +3,87 @@
 namespace Amp;
 
 // @codeCoverageIgnoreStart
-try {
-    if (!@\assert(false)) {
-        development: // PHP 7 development (zend.assertions=1)
-        /**
-         * Deferred is a container for an iterator that can emit values using the emit() method and completed using the
-         * complete() and fail() methods of this object. The contained iterator may be accessed using the iterate()
-         * method. This object should not be part of a public API, but used internally to create and emit values to an
-         * iterator.
-         */
-        final class Emitter {
-            /** @var \Amp\Iterator */
-            private $iterator;
-
-            /** @var callable */
-            private $emit;
-
-            /** @var callable */
-            private $complete;
-
-            /** @var callable */
-            private $fail;
-
-            public function __construct() {
-                $this->iterator = new class($this->emit, $this->complete, $this->fail) implements Iterator {
-                    use CallableMaker, Internal\Producer;
-
-                    public function __construct(&$emit, &$complete, &$fail) {
-                        $emit = $this->callableFromInstanceMethod("emit");
-                        $complete = $this->callableFromInstanceMethod("complete");
-                        $fail = $this->callableFromInstanceMethod("fail");
-                    }
-                };
-            }
-
-            /**
-             * @return \Amp\Iterator
-             */
-            public function iterate(): Iterator {
-                return $this->iterator;
-            }
-
-            /**
-             * Emits a value to the iterator.
-             *
-             * @param mixed $value
-             *
-             * @return \Amp\Promise
-             */
-            public function emit($value): Promise {
-                return ($this->emit)($value);
-            }
-
-            /**
-             * Completes the iterator.
-             */
-            public function complete() {
-                ($this->complete)();
-            }
-
-            /**
-             * Fails the iterator with the given reason.
-             *
-             * @param \Throwable $reason
-             */
-            public function fail(\Throwable $reason) {
-                ($this->fail)($reason);
-            }
-        }
-    } else {
-        production: // PHP 7 production environment (zend.assertions=0)
-        /**
-         * An optimized version of Emitter for production environments that is itself the iterator. Eval is used to
-         * prevent IDEs and other tools from reporting multiple definitions.
-         */
-        eval('namespace Amp;
-        final class Emitter implements Iterator {
-            use Internal\Producer { emit as public; complete as public; fail as public; }
-            public function iterate(): Iterator { return $this; }
-        }');
+if ((function () {
+    if (($env = \getenv("AMP_OPTIMIZATIONS")) === false) {
+        return !(\defined("AMP_OPTIMIZATIONS") && \AMP_OPTIMIZATIONS);
     }
-} catch (\AssertionError $exception) {
-    goto development; // zend.assertions=1 and assert.exception=1, use development definition.
+    return $env === "0" || $env === "false";
+})()) {
+    development: // PHP 7 development (zend.assertions=1)
+    /**
+     * Deferred is a container for an iterator that can emit values using the emit() method and completed using the
+     * complete() and fail() methods of this object. The contained iterator may be accessed using the iterate()
+     * method. This object should not be part of a public API, but used internally to create and emit values to an
+     * iterator.
+     */
+    final class Emitter {
+        /** @var \Amp\Iterator */
+        private $iterator;
+
+        /** @var callable */
+        private $emit;
+
+        /** @var callable */
+        private $complete;
+
+        /** @var callable */
+        private $fail;
+
+        public function __construct() {
+            $this->iterator = new class($this->emit, $this->complete, $this->fail) implements Iterator {
+                use CallableMaker, Internal\Producer;
+
+                public function __construct(&$emit, &$complete, &$fail) {
+                    $emit = $this->callableFromInstanceMethod("emit");
+                    $complete = $this->callableFromInstanceMethod("complete");
+                    $fail = $this->callableFromInstanceMethod("fail");
+                }
+            };
+        }
+
+        /**
+         * @return \Amp\Iterator
+         */
+        public function iterate(): Iterator {
+            return $this->iterator;
+        }
+
+        /**
+         * Emits a value to the iterator.
+         *
+         * @param mixed $value
+         *
+         * @return \Amp\Promise
+         */
+        public function emit($value): Promise {
+            return ($this->emit)($value);
+        }
+
+        /**
+         * Completes the iterator.
+         */
+        public function complete() {
+            ($this->complete)();
+        }
+
+        /**
+         * Fails the iterator with the given reason.
+         *
+         * @param \Throwable $reason
+         */
+        public function fail(\Throwable $reason) {
+            ($this->fail)($reason);
+        }
+    }
+} else {
+    production: // PHP 7 production environment (zend.assertions=0)
+    /**
+     * An optimized version of Emitter for production environments that is itself the iterator. Eval is used to
+     * prevent IDEs and other tools from reporting multiple definitions.
+     */
+    eval('namespace Amp;
+    final class Emitter implements Iterator {
+        use Internal\Producer { emit as public; complete as public; fail as public; }
+        public function iterate(): Iterator { return $this; }
+    }');
 } // @codeCoverageIgnoreEnd

--- a/lib/Promise.php
+++ b/lib/Promise.php
@@ -2,6 +2,12 @@
 
 namespace Amp;
 
+// Issue a notice if AMP_OPTIMIZATIONS is not defined.
+if (\getenv("AMP_OPTIMIZATIONS") === false && !\defined("AMP_OPTIMIZATIONS")) {
+    \trigger_error("Amp is running in development mode. Define environment variable AMP_OPTIMIZATIONS or "
+        . "const AMP_OPTIMIZATIONS to hide this notice. Use a truthy value to run in production mode", E_USER_NOTICE);
+}
+
 /**
  * Representation of the future value of an asynchronous operation.
  */

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,9 @@
         processIsolation="false"
         stopOnFailure="false"
 >
+    <php>
+        <env name="AMP_OPTIMIZATIONS" value="false"/>
+    </php>
     <testsuites>
         <testsuite name="Main">
             <directory>test</directory>


### PR DESCRIPTION
Addresses #157.

Instead of using assertions to toggle Amp's `Deferred`/`Emitter` optimizations, this PR uses either an environment variable or const `AMP_OPTIMIZATIONS`. If neither of these are defined, an `E_USER_NOTICE` is issued.

I think this is a better approach to enabling optimizations, as it is more obvious to the user and does not depend the setting for assertions, which commonly are configured incorrectly for the environment, tending to default to off.

I put the code to issue the notice in the `Promise` class definition file. This was a rather arbitrary place (only chosen because the optimizations relate to promises) and if someone has a better suggestion please let me know.