### PR TITLE
Drop multiple definitions of Deferred and Emitter

### DIFF
--- a/lib/Deferred.php
+++ b/lib/Deferred.php
@@ -2,73 +2,46 @@
 
 namespace Amp;
 
-// @codeCoverageIgnoreStart
-try {
-    if (!@\assert(false)) {
-        development: // PHP 7 development (zend.assertions=1)
-        /**
-         * Deferred is a container for a promise that is resolved using the resolve() and fail() methods of this object.
-         * The contained promise may be accessed using the promise() method. This object should not be part of a public
-         * API, but used internally to create and resolve a promise.
-         */
-        final class Deferred {
-            /** @var \Amp\Promise */
-            private $promise;
+/**
+ * Deferred is a container for a promise that is resolved using the resolve() and fail() methods of this object.
+ * The contained promise may be accessed using the promise() method. This object should not be part of a public
+ * API, but used internally to create and resolve a promise.
+ */
+final class Deferred {
+    /** @var \Amp\Promise */
+    private $promise;
 
-            /** @var callable */
-            private $resolve;
-
-            /** @var callable */
-            private $fail;
-
-            public function __construct() {
-                $this->promise = new class($this->resolve, $this->fail) implements Promise {
-                    use CallableMaker, Internal\Placeholder;
-
-                    public function __construct(&$resolve, &$fail) {
-                        $resolve = $this->callableFromInstanceMethod("resolve");
-                        $fail = $this->callableFromInstanceMethod("fail");
-                    }
-                };
+    public function __construct() {
+        $this->promise = new class implements Promise {
+            use Internal\Placeholder {
+                resolve as public;
+                fail as public;
             }
-
-            /**
-             * @return \Amp\Promise
-             */
-            public function promise(): Promise {
-                return $this->promise;
-            }
-
-            /**
-             * Fulfill the promise with the given value.
-             *
-             * @param mixed $value
-             */
-            public function resolve($value = null) {
-                ($this->resolve)($value);
-            }
-
-            /**
-             * Fails the promise the the given reason.
-             *
-             * @param \Throwable $reason
-             */
-            public function fail(\Throwable $reason) {
-                ($this->fail)($reason);
-            }
-        }
-    } else {
-        production: // PHP 7 production environment (zend.assertions=0)
-        /**
-         * An optimized version of Deferred for production environments that is itself the promise. Eval is used to
-         * prevent IDEs and other tools from reporting multiple definitions.
-         */
-        eval('namespace Amp;
-        final class Deferred implements Promise {
-            use Internal\Placeholder { resolve as public; fail as public; }
-            public function promise(): Promise { return $this; }
-        }');
+        };
     }
-} catch (\AssertionError $exception) {
-    goto development; // zend.assertions=1 and assert.exception=1, use development definition.
-} // @codeCoverageIgnoreEnd
+
+    /**
+     * @return \Amp\Promise
+     */
+    public function promise(): Promise {
+        return $this->promise;
+    }
+
+    /**
+     * Fulfill the promise with the given value.
+     *
+     * @param mixed $value
+     */
+    public function resolve($value = null) {
+        $this->promise->resolve($value);
+    }
+
+    /**
+     * Fails the promise the the given reason.
+     *
+     * @param \Throwable $reason
+     */
+    public function fail(\Throwable $reason) {
+        $this->promise->fail($reason);
+    }
+}

--- a/lib/Emitter.php
+++ b/lib/Emitter.php
@@ -2,87 +2,57 @@
 
 namespace Amp;
 
-// @codeCoverageIgnoreStart
-try {
-    if (!@\assert(false)) {
-        development: // PHP 7 development (zend.assertions=1)
-        /**
-         * Deferred is a container for an iterator that can emit values using the emit() method and completed using the
-         * complete() and fail() methods of this object. The contained iterator may be accessed using the iterate()
-         * method. This object should not be part of a public API, but used internally to create and emit values to an
-         * iterator.
-         */
-        final class Emitter {
-            /** @var \Amp\Iterator */
-            private $iterator;
+/**
+ * Emitter is a container for an iterator that can emit values using the emit() method and completed using the
+ * complete() and fail() methods of this object. The contained iterator may be accessed using the iterate()
+ * method. This object should not be part of a public API, but used internally to create and emit values to an
+ * iterator.
+ */
+final class Emitter {
+    /** @var \Amp\Iterator */
+    private $iterator;
 
-            /** @var callable */
-            private $emit;
-
-            /** @var callable */
-            private $complete;
-
-            /** @var callable */
-            private $fail;
-
-            public function __construct() {
-                $this->iterator = new class($this->emit, $this->complete, $this->fail) implements Iterator {
-                    use CallableMaker, Internal\Producer;
-
-                    public function __construct(&$emit, &$complete, &$fail) {
-                        $emit = $this->callableFromInstanceMethod("emit");
-                        $complete = $this->callableFromInstanceMethod("complete");
-                        $fail = $this->callableFromInstanceMethod("fail");
-                    }
-                };
+    public function __construct() {
+        $this->iterator = new class implements Iterator {
+            use Internal\Producer {
+                emit as public;
+                complete as public;
+                fail as public;
             }
-
-            /**
-             * @return \Amp\Iterator
-             */
-            public function iterate(): Iterator {
-                return $this->iterator;
-            }
-
-            /**
-             * Emits a value to the iterator.
-             *
-             * @param mixed $value
-             *
-             * @return \Amp\Promise
-             */
-            public function emit($value): Promise {
-                return ($this->emit)($value);
-            }
-
-            /**
-             * Completes the iterator.
-             */
-            public function complete() {
-                ($this->complete)();
-            }
-
-            /**
-             * Fails the iterator with the given reason.
-             *
-             * @param \Throwable $reason
-             */
-            public function fail(\Throwable $reason) {
-                ($this->fail)($reason);
-            }
-        }
-    } else {
-        production: // PHP 7 production environment (zend.assertions=0)
-        /**
-         * An optimized version of Emitter for production environments that is itself the iterator. Eval is used to
-         * prevent IDEs and other tools from reporting multiple definitions.
-         */
-        eval('namespace Amp;
-        final class Emitter implements Iterator {
-            use Internal\Producer { emit as public; complete as public; fail as public; }
-            public function iterate(): Iterator { return $this; }
-        }');
+        };
     }
-} catch (\AssertionError $exception) {
-    goto development; // zend.assertions=1 and assert.exception=1, use development definition.
-} // @codeCoverageIgnoreEnd
+
+    /**
+     * @return \Amp\Promise
+     */
+    public function iterate(): Iterator {
+        return $this->iterator;
+    }
+
+    /**
+     * Emits a value to the iterator.
+     *
+     * @param mixed $value
+     *
+     * @return \Amp\Promise
+     */
+    public function emit($value): Promise {
+        return $this->iterator->emit($value);
+    }
+
+    /**
+     * Completes the iterator.
+     */
+    public function complete() {
+        $this->iterator->complete();
+    }
+
+    /**
+     * Fails the iterator with the given reason.
+     *
+     * @param \Throwable $reason
+     */
+    public function fail(\Throwable $reason) {
+        $this->iterator->fail($reason);
+    }
+}


### PR DESCRIPTION
Alternative to #189, simply dropping the optimization when assertions are enabled.

`Deferred` and `Emitter` return objects with public methods that allow resolution/emitting/etc., but IDEs (at least not PhpStorm) will not hint those methods. I think the potential for abuse is slim, it's fairly clear that those methods are not suppose to be used. Such code would likely be fragile or throw when the promise is resolved again.

As @kelunik mentioned, the use of `Deferred` is much lower with Amp v2, particularly in user-code and high-level Amp libs which mostly use coroutines. Between this and the performance gains of PHP 7, perhaps this performance hack isn't necessary anymore.