### PR TITLE
Hide resolution methods

### DIFF
--- a/lib/Deferred.php
+++ b/lib/Deferred.php
@@ -15,23 +15,14 @@ final class Deferred {
     private $promise;
 
     public function __construct() {
-        $this->resolver = new class {
+        $this->resolver = new class implements Promise {
             use Internal\Placeholder {
                 resolve as public;
                 fail as public;
             }
         };
 
-        $this->promise = new class($this->resolver) implements Promise {
-            /** @var \Amp\Promise */
-            private $promise;
-            public function __construct($promise) {
-                $this->promise = $promise;
-            }
-            public function onResolve(callable $onResolved) {
-                $this->promise->onResolve($onResolved);
-            }
-        };
+        $this->promise = new Internal\PrivatePromise($this->resolver);
     }
 
     /**

--- a/lib/Emitter.php
+++ b/lib/Emitter.php
@@ -16,7 +16,7 @@ final class Emitter {
     private $iterator;
 
     public function __construct() {
-        $this->emitter = new class {
+        $this->emitter = new class implements Iterator {
             use Internal\Producer {
                 emit as public;
                 complete as public;
@@ -24,19 +24,7 @@ final class Emitter {
             }
         };
 
-        $this->iterator = new class($this->emitter) implements Iterator {
-            /** @var \Amp\Iterator */
-            private $iterator;
-            public function __construct($iterator) {
-                $this->iterator = $iterator;
-            }
-            public function advance(): Promise {
-                return $this->iterator->advance();
-            }
-            public function getCurrent() {
-                return $this->iterator->getCurrent();
-            }
-        };
+        $this->iterator = new Internal\PrivateIterator($this->emitter);
     }
 
     /**

--- a/lib/Internal/PrivateIterator.php
+++ b/lib/Internal/PrivateIterator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Amp\Internal;
+
+use Amp\Iterator;
+use Amp\Promise;
+
+/**
+ * Wraps an Iterator instance that has public methods to emit, complete, and fail into an object that only allows
+ * access to the public API methods.
+ */
+class PrivateIterator implements Iterator {
+    /** @var \Amp\Iterator */
+    private $iterator;
+
+    public function __construct(Iterator $iterator) {
+        $this->iterator = $iterator;
+    }
+
+    public function advance(): Promise {
+        return $this->iterator->advance();
+    }
+
+    public function getCurrent() {
+        return $this->iterator->getCurrent();
+    }
+}

--- a/lib/Internal/PrivatePromise.php
+++ b/lib/Internal/PrivatePromise.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Amp\Internal;
+
+use Amp\Promise;
+
+/**
+ * Wraps a Promise instance that has public methods to resolve and fail the promise into an object that only allows
+ * access to the public API methods.
+ */
+class PrivatePromise implements Promise {
+    /** @var \Amp\Promise */
+    private $promise;
+
+    public function __construct(Promise $promise) {
+        $this->promise = $promise;
+    }
+
+    public function onResolve(callable $onResolved) {
+        $this->promise->onResolve($onResolved);
+    }
+}


### PR DESCRIPTION
This modifies `Deferred` and `Emitter` to create another object without resolution methods that can be returned from `promise()` and `iterate()` respectively. This does have a slight negative performance impact, but would completely prevent users from shooting themselves in the foot. As noted in #190, most Amp code uses coroutines now, so I think actual performance impact is negligible.