### PR TITLE
Relieve back-pressure on iterator when destoryed

### DIFF
--- a/lib/DisposedException.php
+++ b/lib/DisposedException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace Amp;
+
+class DisposedException extends \Exception {
+}

--- a/lib/Emitter.php
+++ b/lib/Emitter.php
@@ -13,7 +13,7 @@ final class Emitter {
     private $iterator;
 
     public function __construct() {
-        $this->iterator = new class implements Iterator {
+        $this->iterator = new class {
             use Internal\Producer {
                 emit as public;
                 complete as public;
@@ -26,7 +26,7 @@ final class Emitter {
      * @return \Amp\Promise
      */
     public function iterate(): Iterator {
-        return $this->iterator;
+        return $this->iterator->iterate();
     }
 
     /**

--- a/lib/Internal/Producer.php
+++ b/lib/Internal/Producer.php
@@ -2,8 +2,11 @@
 
 namespace Amp\Internal;
 
+use Amp\CallableMaker;
 use Amp\Deferred;
+use Amp\DisposedException;
 use Amp\Failure;
+use Amp\Iterator;
 use Amp\Promise;
 use Amp\Success;
 use React\Promise\PromiseInterface as ReactPromise;
@@ -11,12 +14,12 @@ use React\Promise\PromiseInterface as ReactPromise;
 /**
  * Trait used by Iterator implementations. Do not use this trait in your code, instead compose your class from one of
  * the available classes implementing \Amp\Iterator.
- * Note that it is the responsibility of the user of this trait to ensure that listeners have a chance to listen first
- * before emitting values.
  *
  * @internal
  */
 trait Producer {
+    use CallableMaker;
+
     /** @var \Amp\Promise|null */
     private $complete;
 
@@ -26,61 +29,64 @@ trait Producer {
     /** @var \Amp\Deferred[] */
     private $backPressure = [];
 
+    /** @var \Amp\Deferred|null */
+    private $waiting;
+
     /** @var int */
     private $position = -1;
 
-    /** @var \Amp\Deferred|null */
-    private $waiting;
+    /** @var bool */
+    private $disposed = false;
+
+    /** @var \Amp\DisposedException|null */
+    private $exception;
 
     /** @var null|array */
     private $resolutionTrace;
 
     /**
-     * {@inheritdoc}
+     * Returns an iterator instance that when destroyed fails the producer with an instance of \Amp\DisposedException.
+     *
+     * @return \Amp\Iterator
      */
-    public function advance(): Promise {
-        if ($this->waiting !== null) {
-            throw new \Error("The prior promise returned must resolve before invoking this method again");
-        }
+    public function iterate(): Iterator {
+        $advance = $this->callableFromInstanceMethod("advance");
+        $current = $this->callableFromInstanceMethod("getCurrent");
+        $dispose = $this->callableFromInstanceMethod("dispose");
 
-        if (isset($this->backPressure[$this->position])) {
-            $future = $this->backPressure[$this->position];
-            unset($this->values[$this->position], $this->backPressure[$this->position]);
-            $future->resolve();
-        }
+        return new class($advance, $current, $dispose) implements Iterator {
+            /** @var callable */
+            private $advance;
 
-        ++$this->position;
+            /** @var callable */
+            private $current;
 
-        if (\array_key_exists($this->position, $this->values)) {
-            return new Success(true);
-        }
+            /** @var callable */
+            private $dispose;
 
-        if ($this->complete) {
-            return $this->complete;
-        }
+            public function __construct(callable $advance, callable $current, callable $dispose) {
+                $this->advance = $advance;
+                $this->current = $current;
+                $this->dispose = $dispose;
+            }
 
-        $this->waiting = new Deferred;
-        return $this->waiting->promise();
+            public function __destruct() {
+                ($this->dispose)();
+            }
+
+            public function advance(): Promise {
+                return ($this->advance)();
+            }
+
+            public function getCurrent() {
+                return ($this->current)();
+            }
+        };
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function getCurrent() {
-        if (empty($this->values) && $this->complete) {
-            throw new \Error("The iterator has completed");
-        }
-
-        if (!\array_key_exists($this->position, $this->values)) {
-            throw new \Error("Promise returned from advance() must resolve before calling this method");
-        }
-
-        return $this->values[$this->position];
-    }
-
-    /**
-     * Emits a value from the iterator. The returned promise is resolved with the emitted value once all listeners
-     * have been invoked.
+     * Emits a value from the iterator. The returned promise is resolved with the emitted value once it has been
+     * consumed.
      *
      * @param mixed $value
      *
@@ -92,6 +98,15 @@ trait Producer {
         if ($this->complete) {
             throw new \Error("Iterators cannot emit values after calling complete");
         }
+
+        if ($this->disposed) {
+            if (!$this->exception) {
+                $this->exception = new DisposedException("The iterator has been disposed");
+            }
+
+            return new Failure($this->exception);
+        }
+
 
         if ($value instanceof ReactPromise) {
             $value = Promise\adapt($value);
@@ -129,6 +144,58 @@ trait Producer {
         }
 
         return $pressure->promise();
+    }
+
+    private function advance(): Promise {
+        if ($this->waiting !== null) {
+            throw new \Error("The prior promise returned must resolve before invoking this method again");
+        }
+
+        if (isset($this->backPressure[$this->position])) {
+            $deferred = $this->backPressure[$this->position];
+            unset($this->backPressure[$this->position]);
+            $deferred->resolve();
+        }
+
+        unset($this->values[$this->position]);
+
+        ++$this->position;
+
+        if (\array_key_exists($this->position, $this->values)) {
+            return new Success(true);
+        }
+
+        if ($this->complete) {
+            return $this->complete;
+        }
+
+        $this->waiting = new Deferred;
+        return $this->waiting->promise();
+    }
+
+    private function getCurrent() {
+        if (empty($this->values) && $this->complete) {
+            throw new \Error("The iterator has completed");
+        }
+
+        if (!\array_key_exists($this->position, $this->values)) {
+            throw new \Error("Promise returned from advance() must resolve before calling this method");
+        }
+
+        return $this->values[$this->position];
+    }
+
+    private function dispose() {
+        if ($this->backPressure) {
+            $this->exception = new DisposedException("The iterator has been disposed");
+            for ($key = \key($this->backPressure); isset($this->backPressure[$key]); $key++) {
+                $deferred = $this->backPressure[$key];
+                unset($this->values[$key], $this->backPressure[$key]);
+                $deferred->fail($this->exception);
+            }
+        }
+
+        $this->disposed = true;
     }
 
     /**

--- a/lib/Producer.php
+++ b/lib/Producer.php
@@ -3,7 +3,10 @@
 namespace Amp;
 
 final class Producer implements Iterator {
-    use CallableMaker, Internal\Producer;
+    use Internal\Producer {
+        advance as public;
+        getCurrent as public;
+    }
 
     /**
      * @param callable(callable(mixed $value): Promise $emit): \Generator $producer


### PR DESCRIPTION
This provides a mechanism that relieves all back-pressure and fails future emits with an instance of `Amp\DisposedException` when the consumer of the iterator object destroys the object returned from `Producer::iterate()`. Currently the back-pressure promise never resolved, potentially leading to memory leaks or hanging.