### PR TITLE
Add Loop::now()

### DIFF
--- a/docs/event-loop/api.md
+++ b/docs/event-loop/api.md
@@ -15,6 +15,10 @@ The primary way an application interacts with the event loop is to schedule even
 
 The event loop can be stopped at any time while running. When `Loop::stop()` is invoked the event loop will return control to the userland script at the end of the current tick of the event loop. This method may be used to yield control from the event loop even if events or watchable IO streams are still pending.
 
+## `now()`
+
+Returns the current 'loop time' in millisecond increments. The value returned by this method does not necessarily correlate to wall-clock time, rather the value is meant to be used in relative comparisons to prior values returned by this method (e.g.: interval calculations, expiration times, etc.). The value returned by this method is only updated once per loop tick. This method is a faster alternative to `time()` and `microtime()`, which require a system call.
+
 ## Timer Watchers
 
 Amp exposes several ways to schedule timer watchers. Let's look at some details for each function.

--- a/lib/Loop.php
+++ b/lib/Loop.php
@@ -333,6 +333,18 @@ final class Loop
     }
 
     /**
+     * Returns the current loop time in millisecond increments. Note this value does not necessarily correlate to
+     * wall-clock time, rather the value returned is meant to be used in relative comparisons to prior values returned
+     * by this method (intervals, expiration calculations, etc.) and is only updated once per loop tick.
+     *
+     * @return int
+     */
+    public static function now(): int
+    {
+        return self::$driver->now();
+    }
+
+    /**
      * Stores information in the loop bound registry.
      *
      * Stored information is package private. Packages MUST NOT retrieve the stored state of other packages. Packages

--- a/lib/Loop/Driver.php
+++ b/lib/Loop/Driver.php
@@ -591,6 +591,20 @@ abstract class Driver
     }
 
     /**
+     * Returns the current loop time in millisecond increments. Note this value does not necessarily correlate to
+     * wall-clock time, rather the value returned is meant to be used in relative comparisons to prior values returned
+     * by this method (intervals, expiration calculations, etc.) and is only updated once per loop tick.
+     *
+     * Extending classes should override this function to return a value cached once per loop tick.
+     *
+     * @return int
+     */
+    public function now(): int
+    {
+        return \microtime(true) * self::MILLISEC_PER_SEC;
+    }
+
+    /**
      * Get the underlying loop handle.
      *
      * Example: the `uv_loop` resource for `libuv` or the `EvLoop` object for `libev` or `null` for a native driver.

--- a/lib/Loop/EvDriver.php
+++ b/lib/Loop/EvDriver.php
@@ -31,7 +31,7 @@ class EvDriver extends Driver
     private $signals = [];
 
     /** @var int Internal timestamp for now. */
-    private $now = 0;
+    private $now;
 
     /** @var bool */
     private $nowUpdateNeeded = false;
@@ -43,6 +43,8 @@ class EvDriver extends Driver
     {
         $this->handle = new \EvLoop;
         $this->nowOffset = (int) (\microtime(true) * self::MILLISEC_PER_SEC);
+        $this->now = \random_int(0, $this->nowOffset);
+        $this->nowOffset -= $this->now;
 
         if (self::$activeSignals === null) {
             self::$activeSignals = &$this->signals;

--- a/lib/Loop/EventDriver.php
+++ b/lib/Loop/EventDriver.php
@@ -34,7 +34,7 @@ class EventDriver extends Driver
     private $nowUpdateNeeded = false;
 
     /** @var int Internal timestamp for now. */
-    private $now = 0;
+    private $now;
 
     /** @var int Loop time offset from microtime() */
     private $nowOffset;
@@ -43,6 +43,8 @@ class EventDriver extends Driver
     {
         $this->handle = new \EventBase;
         $this->nowOffset = (int) (\microtime(true) * self::MILLISEC_PER_SEC);
+        $this->now = \random_int(0, $this->nowOffset);
+        $this->nowOffset -= $this->now;
 
         if (self::$activeSignals === null) {
             self::$activeSignals = &$this->signals;

--- a/lib/Loop/NativeDriver.php
+++ b/lib/Loop/NativeDriver.php
@@ -34,7 +34,7 @@ class NativeDriver extends Driver
     private $nowUpdateNeeded = false;
 
     /** @var int Internal timestamp for now. */
-    private $now = 0;
+    private $now;
 
     /** @var int Loop time offset from microtime() */
     private $nowOffset;
@@ -47,6 +47,8 @@ class NativeDriver extends Driver
         $this->timerQueue = new \SplPriorityQueue();
         $this->signalHandling = \extension_loaded("pcntl");
         $this->nowOffset = (int) (\microtime(true) * self::MILLISEC_PER_SEC);
+        $this->now = \random_int(0, $this->nowOffset);
+        $this->nowOffset -= $this->now;
     }
 
     /**
@@ -125,6 +127,10 @@ class NativeDriver extends Driver
                     try {
                         // Execute the timer.
                         $result = ($watcher->callback)($id, $watcher->data);
+
+                        if ($result === null) {
+                            continue;
+                        }
 
                         if ($result instanceof \Generator) {
                             $result = new Coroutine($result);

--- a/lib/Loop/UvDriver.php
+++ b/lib/Loop/UvDriver.php
@@ -169,6 +169,14 @@ class UvDriver extends Driver
     /**
      * {@inheritdoc}
      */
+    public function now(): int
+    {
+        return \uv_now($this->handle);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getHandle()
     {
         return $this->handle;

--- a/test/Loop/DriverTest.php
+++ b/test/Loop/DriverTest.php
@@ -1555,6 +1555,23 @@ abstract class DriverTest extends TestCase
         $this->assertNotSame(0, $j);
     }
 
+    public function testNow()
+    {
+        $now = $this->loop->now();
+        $this->loop->delay(100, function () use ($now) {
+            $now += 100;
+            $new = $this->loop->now();
+
+            // Allow a few milliseconds of inaccuracy.
+            $this->assertGreaterThanOrEqual($now - 5, $new);
+            $this->assertLessThanOrEqual($now + 5, $new);
+
+            // Same time should be returned from later call.
+            $this->assertSame($new, $this->loop->now());
+        });
+        $this->loop->run();
+    }
+
     public function testBug163ConsecutiveDelayed()
     {
         $emits = 3;

--- a/test/LoopTest.php
+++ b/test/LoopTest.php
@@ -46,12 +46,30 @@ class LoopTest extends TestCase
         });
     }
 
+    public function testNow()
+    {
+        Loop::run(function () {
+            $now = Loop::now();
+            Loop::delay(100, function () use ($now) {
+                $now += 100;
+                $new = Loop::now();
+
+                // Allow a few milliseconds of inaccuracy.
+                $this->assertGreaterThanOrEqual($now - 5, $new);
+                $this->assertLessThanOrEqual($now + 5, $new);
+
+                // Same time should be returned from later call.
+                $this->assertSame($new, Loop::now());
+            });
+        });
+    }
+
     public function testGet()
     {
         $this->assertInstanceOf(Loop\Driver::class, Loop::get());
     }
 
-    public function testGetInto()
+    public function testGetInfo()
     {
         $this->assertSame(Loop::get()->getInfo(), Loop::getInfo());
     }


### PR DESCRIPTION
We frequently use `microtime()` or `time()` to keep track of last activity time, update time, etc. These system calls are relatively expensive. `Loop::now()` updates only on the first call in a tick (or in `UvLoop` the function `uv_now()` is used).