### PR TITLE
Alternative approach to adding Loop::now()

### DIFF
--- a/docs/event-loop/api.md
+++ b/docs/event-loop/api.md
@@ -15,6 +15,10 @@ The primary way an application interacts with the event loop is to schedule even
 
 The event loop can be stopped at any time while running. When `Loop::stop()` is invoked the event loop will return control to the userland script at the end of the current tick of the event loop. This method may be used to yield control from the event loop even if events or watchable IO streams are still pending.
 
+## `now()`
+
+Returns the current 'loop time' in millisecond increments. The value returned by this method does not necessarily correlate to wall-clock time, rather the value is meant to be used in relative comparisons to prior values returned by this method (e.g.: interval calculations, expiration times, etc.). The value returned by this method is only updated once per loop tick. This method is a faster alternative to `time()` and `microtime()`, which require a system call.
+
 ## Timer Watchers
 
 Amp exposes several ways to schedule timer watchers. Let's look at some details for each function.

--- a/lib/Loop.php
+++ b/lib/Loop.php
@@ -333,6 +333,18 @@ final class Loop
     }
 
     /**
+     * Returns the current loop time in millisecond increments. Note this value does not necessarily correlate to
+     * wall-clock time, rather the value returned is meant to be used in relative comparisons to prior values returned
+     * by this method (intervals, expiration calculations, etc.) and is only updated once per loop tick.
+     *
+     * @return int
+     */
+    public static function now(): int
+    {
+        return self::$driver->now();
+    }
+
+    /**
      * Stores information in the loop bound registry.
      *
      * Stored information is package private. Packages MUST NOT retrieve the stored state of other packages. Packages

--- a/lib/Loop/Driver.php
+++ b/lib/Loop/Driver.php
@@ -45,6 +45,12 @@ abstract class Driver
     /** @var array */
     private $registry = [];
 
+    /** @var bool */
+    private $nowUpdateNeeded = true;
+
+    /** @var int Internal timestamp for now. */
+    private $now;
+
     /**
      * Run the event loop.
      *
@@ -130,6 +136,8 @@ abstract class Driver
                 $this->error($exception);
             }
         }
+
+        $this->nowUpdateNeeded = true;
 
         $this->dispatch(empty($this->nextTickQueue) && empty($this->enableQueue) && $this->running && !$this->isEmpty());
     }
@@ -588,6 +596,23 @@ abstract class Driver
         }
 
         ($this->errorHandler)($exception);
+    }
+
+    /**
+     * Returns the current loop time in millisecond increments. Note this value does not necessarily correlate to
+     * wall-clock time, rather the value returned is meant to be used in relative comparisons to prior values returned
+     * by this method (intervals, expiration calculations, etc.) and is only updated once per loop tick.
+     *
+     * @return int
+     */
+    public function now(): int
+    {
+        if ($this->nowUpdateNeeded) {
+            $this->now = (int) (\microtime(true) * self::MILLISEC_PER_SEC);
+            $this->nowUpdateNeeded = false;
+        }
+
+        return $this->now;
     }
 
     /**

--- a/lib/Loop/Driver.php
+++ b/lib/Loop/Driver.php
@@ -607,7 +607,7 @@ abstract class Driver
      */
     public function now(): int
     {
-        if ($this->nowUpdateNeeded) {
+        if ($this->nowUpdateNeeded || !$this->running) {
             $this->now = (int) (\microtime(true) * self::MILLISEC_PER_SEC);
             $this->nowUpdateNeeded = false;
         }

--- a/lib/Loop/EvDriver.php
+++ b/lib/Loop/EvDriver.php
@@ -11,16 +11,22 @@ class EvDriver extends Driver
 {
     /** @var \EvSignal[]|null */
     private static $activeSignals;
+
     /** @var \EvLoop */
     private $handle;
+
     /** @var \EvWatcher[] */
     private $events = [];
+
     /** @var callable */
     private $ioCallback;
+
     /** @var callable */
     private $timerCallback;
+
     /** @var callable */
     private $signalCallback;
+
     /** @var \EvSignal[] */
     private $signals = [];
 

--- a/lib/Loop/EventDriver.php
+++ b/lib/Loop/EventDriver.php
@@ -11,25 +11,29 @@ class EventDriver extends Driver
 {
     /** @var \Event[]|null */
     private static $activeSignals;
+
     /** @var \EventBase */
     private $handle;
+
     /** @var \Event[] */
     private $events = [];
+
     /** @var callable */
     private $ioCallback;
+
     /** @var callable */
     private $timerCallback;
+
     /** @var callable */
     private $signalCallback;
+
     /** @var \Event[] */
     private $signals = [];
-    /** @var int Internal timestamp for now. */
-    private $now;
 
     public function __construct()
     {
         $this->handle = new \EventBase;
-        $this->now = (int) (\microtime(true) * self::MILLISEC_PER_SEC);
+        $this->now(); // Initialize initial tick time when constructing.
 
         if (self::$activeSignals === null) {
             self::$activeSignals = &$this->signals;
@@ -198,7 +202,6 @@ class EventDriver extends Driver
     protected function dispatch(bool $blocking)
     {
         $this->handle->loop($blocking ? \EventBase::LOOP_ONCE : \EventBase::LOOP_ONCE | \EventBase::LOOP_NONBLOCK);
-        $this->now = (int) (\microtime(true) * self::MILLISEC_PER_SEC);
     }
 
     /**
@@ -262,7 +265,7 @@ class EventDriver extends Driver
             switch ($watcher->type) {
                 case Watcher::DELAY:
                 case Watcher::REPEAT:
-                    $interval = $watcher->value - ($now - $this->now);
+                    $interval = $watcher->value - ($now - $this->now());
                     $this->events[$id]->add($interval > 0 ? $interval / self::MILLISEC_PER_SEC : 0);
                     break;
 

--- a/lib/Loop/UvDriver.php
+++ b/lib/Loop/UvDriver.php
@@ -167,6 +167,16 @@ class UvDriver extends Driver
     }
 
     /**
+     * Uses uv_now() instead of microtime().
+     *
+     * @return int
+     */
+    public function now(): int
+    {
+        return \uv_now($this->handle);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getHandle()

--- a/test/Loop/DriverTest.php
+++ b/test/Loop/DriverTest.php
@@ -1555,6 +1555,23 @@ abstract class DriverTest extends TestCase
         $this->assertNotSame(0, $j);
     }
 
+    public function testNow()
+    {
+        $now = $this->loop->now();
+        $this->loop->delay(100, function () use ($now) {
+            $now += 100;
+            $new = $this->loop->now();
+
+            // Allow a few milliseconds of inaccuracy.
+            $this->assertGreaterThanOrEqual($now - 5, $new);
+            $this->assertLessThanOrEqual($now + 5, $new);
+
+            // Same time should be returned from later call.
+            $this->assertSame($new, $this->loop->now());
+        });
+        $this->loop->run();
+    }
+
     public function testBug163ConsecutiveDelayed()
     {
         $emits = 3;

--- a/test/LoopTest.php
+++ b/test/LoopTest.php
@@ -46,12 +46,30 @@ class LoopTest extends TestCase
         });
     }
 
+    public function testNow()
+    {
+        Loop::run(function () {
+            $now = Loop::now();
+            Loop::delay(100, function () use ($now) {
+                $now += 100;
+                $new = Loop::now();
+
+                // Allow a few milliseconds of inaccuracy.
+                $this->assertGreaterThanOrEqual($now - 5, $new);
+                $this->assertLessThanOrEqual($now + 5, $new);
+
+                // Same time should be returned from later call.
+                $this->assertSame($new, Loop::now());
+            });
+        });
+    }
+
     public function testGet()
     {
         $this->assertInstanceOf(Loop\Driver::class, Loop::get());
     }
 
-    public function testGetInto()
+    public function testGetInfo()
     {
         $this->assertSame(Loop::get()->getInfo(), Loop::getInfo());
     }


### PR DESCRIPTION
This PR (hopefully) adds `Loop::now()` in a BC way.