### PR TITLE
Fix 212 and ignore unreference on invalid watchers

### DIFF
--- a/lib/Loop.php
+++ b/lib/Loop.php
@@ -247,6 +247,12 @@ final class Loop {
      * @return void
      */
     public static function disable(string $watcherId) {
+        if (!isset(self::$driver)) {
+            // Prior to PHP 7.2, self::$driver may be unset during destruct.
+            // See https://github.com/amphp/amp/issues/212.
+            return;
+        }
+
         self::$driver->disable($watcherId);
     }
 
@@ -261,6 +267,12 @@ final class Loop {
      * @return void
      */
     public static function cancel(string $watcherId) {
+        if (!isset(self::$driver)) {
+            // Prior to PHP 7.2, self::$driver may be unset during destruct.
+            // See https://github.com/amphp/amp/issues/212.
+            return;
+        }
+
         self::$driver->cancel($watcherId);
     }
 

--- a/lib/Loop.php
+++ b/lib/Loop.php
@@ -301,10 +301,14 @@ final class Loop {
      * @param string $watcherId The watcher identifier.
      *
      * @return void
-     *
-     * @throws InvalidWatcherError If the watcher identifier is invalid.
      */
     public static function unreference(string $watcherId) {
+        if (!isset(self::$driver)) {
+            // Prior to PHP 7.2, self::$driver may be unset during destruct.
+            // See https://github.com/amphp/amp/issues/212.
+            return;
+        }
+
         self::$driver->unreference($watcherId);
     }
 

--- a/lib/Loop.php
+++ b/lib/Loop.php
@@ -247,7 +247,7 @@ final class Loop {
      * @return void
      */
     public static function disable(string $watcherId) {
-        if (!isset(self::$driver)) {
+        if (\PHP_VERSION_ID < 70200 && !isset(self::$driver)) {
             // Prior to PHP 7.2, self::$driver may be unset during destruct.
             // See https://github.com/amphp/amp/issues/212.
             return;
@@ -267,7 +267,7 @@ final class Loop {
      * @return void
      */
     public static function cancel(string $watcherId) {
-        if (!isset(self::$driver)) {
+        if (\PHP_VERSION_ID < 70200 && !isset(self::$driver)) {
             // Prior to PHP 7.2, self::$driver may be unset during destruct.
             // See https://github.com/amphp/amp/issues/212.
             return;
@@ -303,7 +303,7 @@ final class Loop {
      * @return void
      */
     public static function unreference(string $watcherId) {
-        if (!isset(self::$driver)) {
+        if (\PHP_VERSION_ID < 70200 && !isset(self::$driver)) {
             // Prior to PHP 7.2, self::$driver may be unset during destruct.
             // See https://github.com/amphp/amp/issues/212.
             return;

--- a/lib/Loop/Driver.php
+++ b/lib/Loop/Driver.php
@@ -487,12 +487,10 @@ abstract class Driver {
      * @param string $watcherId The watcher identifier.
      *
      * @return void
-     *
-     * @throws InvalidWatcherError If the watcher identifier is invalid.
      */
     public function unreference(string $watcherId) {
         if (!isset($this->watchers[$watcherId])) {
-            throw new InvalidWatcherError($watcherId, "Cannot unreference an invalid watcher identifier: '{$watcherId}'");
+            return;
         }
 
         $this->watchers[$watcherId]->referenced = false;

--- a/test/Loop/DriverTest.php
+++ b/test/Loop/DriverTest.php
@@ -754,14 +754,11 @@ abstract class DriverTest extends TestCase {
         }
     }
 
-    /** @expectedException \Amp\Loop\InvalidWatcherError */
-    public function testExceptionOnUnreferenceNonexistentWatcher() {
-        try {
-            $this->loop->unreference("nonexistentWatcher");
-        } catch (InvalidWatcherError $e) {
-            $this->assertSame("nonexistentWatcher", $e->getWatcherId());
-            throw $e;
-        }
+    public function testSuccessOnUnreferenceNonexistentWatcher() {
+        $this->loop->unreference("nonexistentWatcher");
+
+        // Otherwise risky, throwing fails the test
+        $this->assertTrue(true);
     }
 
     /** @expectedException \Amp\Loop\InvalidWatcherError */


### PR DESCRIPTION
Putting this in the same PR as they're *somewhat* related. I can drop the second commit if we decide we don't want it.

Context for ignoring unreference on invalid loop watchers: [`Processor::ready()` in amphp/mysql](https://github.com/amphp/mysql/blob/f3e1f159c971cd23f87014cb97601d3deae321ec/src/Internal/Processor.php#L172-L177)

When a result or statement is destroyed, the connection is marked as ready. During shutdown, this results in `Socket::unreference()` potentially being called after `Socket::__destruct()` has been called.