### PR TITLE
Don't record stack traces in case of AMP_DEBUG not being set

### DIFF
--- a/lib/Internal/Placeholder.php
+++ b/lib/Internal/Placeholder.php
@@ -94,7 +94,7 @@ trait Placeholder {
         }
 
         \assert((function () {
-            $env = \getenv("AMP_DEBUG");
+            $env = \getenv("AMP_DEBUG") ?: "0";
             if (($env !== "0" && $env !== "false") || (\defined("AMP_DEBUG") && \AMP_DEBUG)) {
                 $trace = \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS);
                 \array_shift($trace); // remove current closure

--- a/lib/Internal/Producer.php
+++ b/lib/Internal/Producer.php
@@ -154,7 +154,7 @@ trait Producer {
         }
 
         \assert((function () {
-            $env = \getenv("AMP_DEBUG");
+            $env = \getenv("AMP_DEBUG") ?: "0";
             if (($env !== "0" && $env !== "false") || (\defined("AMP_DEBUG") && \AMP_DEBUG)) {
                 $trace = \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS);
                 \array_shift($trace); // remove current closure


### PR DESCRIPTION
Fixes #217.