### PR TITLE
Fix EventDriver garbage collection

### DIFF
--- a/lib/Loop/Driver.php
+++ b/lib/Loop/Driver.php
@@ -35,14 +35,14 @@ abstract class Driver {
     /** @var \Amp\Loop\Watcher[] */
     private $nextTickQueue = [];
 
-    /** @var callable|null */
-    private $errorHandler;
-
     /** @var bool */
     private $running = false;
 
     /** @var array */
     private $registry = [];
+
+    /** @var callable|null */
+    protected $errorHandler;
 
     /**
      * Run the event loop.


### PR DESCRIPTION
Cyclic references prevented the garbage collection. I guess this is a bug in the extension, but we can work around it by avoiding these references.

Fixes #177.