### PR TITLE
Fixes #232 - UvDriver, EventDriver & NativeDriver delay for first tick

### DIFF
--- a/lib/Loop/EventDriver.php
+++ b/lib/Loop/EventDriver.php
@@ -23,13 +23,12 @@ class EventDriver extends Driver
     private $signalCallback;
     /** @var \Event[] */
     private $signals = [];
-    /** @var int Internal timestamp for now. */
+    /** @var int|null Internal timestamp for now. */
     private $now;
 
     public function __construct()
     {
         $this->handle = new \EventBase;
-        $this->now = (int) (\microtime(true) * self::MILLISEC_PER_SEC);
 
         if (self::$activeSignals === null) {
             self::$activeSignals = &$this->signals;
@@ -159,6 +158,8 @@ class EventDriver extends Driver
         foreach ($this->signals as $event) {
             $event->add();
         }
+
+        $this->now = (int) (\microtime(true) * self::MILLISEC_PER_SEC);
 
         try {
             parent::run();

--- a/lib/Loop/NativeDriver.php
+++ b/lib/Loop/NativeDriver.php
@@ -30,7 +30,7 @@ class NativeDriver extends Driver
     /** @var \Amp\Loop\Watcher[][] */
     private $signalWatchers = [];
 
-    /** @var int Internal timestamp for now. */
+    /** @var int|null Internal timestamp for now. */
     private $now;
 
     /** @var bool */
@@ -40,7 +40,6 @@ class NativeDriver extends Driver
     {
         $this->timerQueue = new \SplPriorityQueue();
         $this->signalHandling = \extension_loaded("pcntl");
-        $this->now = (int) (\microtime(true) * self::MILLISEC_PER_SEC);
     }
 
     /**
@@ -55,6 +54,16 @@ class NativeDriver extends Driver
         }
 
         return parent::onSignal($signo, $callback, $data);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run()
+    {
+        $this->now = (int) (\microtime(true) * self::MILLISEC_PER_SEC);
+
+        parent::run();
     }
 
     /**

--- a/lib/Loop/UvDriver.php
+++ b/lib/Loop/UvDriver.php
@@ -177,6 +177,16 @@ class UvDriver extends Driver
     /**
      * {@inheritdoc}
      */
+    public function run()
+    {
+        \uv_update_time($this->handle);
+
+        parent::run();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function dispatch(bool $blocking)
     {
         \uv_run($this->handle, $blocking ? \UV::RUN_ONCE : \UV::RUN_NOWAIT);

--- a/test/Loop/DriverTest.php
+++ b/test/Loop/DriverTest.php
@@ -26,20 +26,6 @@ if (!\defined("PHP_INT_MIN")) {
 abstract class DriverTest extends TestCase
 {
     /**
-     * Timing mechanisms between drivers vary on accuracy. Set the target resolution in milliseconds.
-     *
-     * @var int
-     */
-    const DELAY_TEST_RESOLUTION_MS = 1;
-
-    /**
-     * Allow elapsed time assertions to be epsilon ms less than DELAY_TEST_MIN_RESOLUTION_MS.
-     *
-     * @var int
-     */
-    const DELAY_TEST_EPSILON_MS = 0.1;
-
-    /**
      * The DriverFactory to run this test on.
      *
      * @return callable
@@ -1522,17 +1508,19 @@ abstract class DriverTest extends TestCase
         $start = \microtime(true);
         $invoked = false;
         $this->start(function (Driver $loop) use (&$invoked) {
-            $loop->delay(static::DELAY_TEST_RESOLUTION_MS, function () use (&$invoked) {
+            $loop->delay(1, function () use (&$invoked) {
                 $invoked = true;
             });
         });
         $end = \microtime(true);
         $this->assertTrue($invoked, 'The delay callback was not invoked');
 
-        $minElapsedExpected = (static::DELAY_TEST_RESOLUTION_MS - static::DELAY_TEST_EPSILON_MS) / 1000;
-        $actualElapsed = $end - $start;
+        // allow the elapsed time to be epsilon ms less than the delay
+        $epsilon = 0.1;
+        $minElapsedExpected = 1 - $epsilon;
+        $actualElapsed = 1000.0 * ($end - $start);
         $this->assertGreaterThanOrEqual($minElapsedExpected, $actualElapsed);
-        $this->assertLessThan(0.1, $actualElapsed);
+        $this->assertLessThan(100, $actualElapsed);
     }
 
     public function testTimerIntervalDeductedWhenResuming()

--- a/test/Loop/UvDriverTest.php
+++ b/test/Loop/UvDriverTest.php
@@ -9,6 +9,20 @@ use Amp\Loop\UvDriver;
  */
 class UvDriverTest extends DriverTest
 {
+    /**
+     * Timing mechanisms between drivers vary on accuracy. Set the target resolution in milliseconds.
+     *
+     * @var int
+     */
+    const DELAY_TEST_RESOLUTION_MS = 10;
+
+    /**
+     * Allow elapsed time assertions to be epsilon ms less than DELAY_TEST_MIN_RESOLUTION_MS.
+     *
+     * @var int
+     */
+    const DELAY_TEST_EPSILON_MS = 1;
+
     public function getFactory(): callable
     {
         return function () {

--- a/test/Loop/UvDriverTest.php
+++ b/test/Loop/UvDriverTest.php
@@ -9,20 +9,6 @@ use Amp\Loop\UvDriver;
  */
 class UvDriverTest extends DriverTest
 {
-    /**
-     * Timing mechanisms between drivers vary on accuracy. Set the target resolution in milliseconds.
-     *
-     * @var int
-     */
-    const DELAY_TEST_RESOLUTION_MS = 10;
-
-    /**
-     * Allow elapsed time assertions to be epsilon ms less than DELAY_TEST_MIN_RESOLUTION_MS.
-     *
-     * @var int
-     */
-    const DELAY_TEST_EPSILON_MS = 1;
-
     public function getFactory(): callable
     {
         return function () {


### PR DESCRIPTION
Proposal for https://github.com/amphp/amp/issues/232 - Loop Driver timing modifications to be compatible with the reactphp/event-loop test suite.

**Description:** Calculates delays in the title drivers the first time the watcher is activated by `\Amp\Loop\Driver`. This is a **breaking change** as there is a test which expects the delay to be calculated from the construction time of the driver (see `testTimerIntervalCountedWhenNotRunning`). I expect this would have little real-world consequence as it would mean users are adding delays outside of the event loop and using blocking operations before starting the event loop negating the purpose of using an event loop in the first place.

Stopping and resuming the event loop behaves as it did before, i.e. the amount of time elapsed between ticks is considered for the delay interval. `testTimerIntervalCountedWhenNotRunning` has been modified to `testTimerIntervalDeductedWhenResuming` to test for this case.

<strike>Note: `amphp/react-adapter:UvTimerTest` will still need minor adaptation for tests to pass consistently.</strike>

<strike>Is it possible to call `UvDriver::dispatch` prior to run to update the timers?</strike> added `\uv_update_time`.
