### PR TITLE
Fix backpressure release

### DIFF
--- a/examples/iterators/emitter-gc.php
+++ b/examples/iterators/emitter-gc.php
@@ -23,7 +23,6 @@ Loop::run(function () {
 
     $iterator = $emitter->iterate();
     yield $iterator->advance();
-    yield $iterator->advance();
     yield new Amp\Delayed(0);
 
     unset($emitter, $iterator);

--- a/test/ProducerTest.php
+++ b/test/ProducerTest.php
@@ -100,7 +100,7 @@ class ProducerTest extends BaseTest
             }
         });
 
-        $this->assertGreaterThan(self::TIMEOUT * $emits - 1 /* 1ms grace period */, $time * 1000);
+        $this->assertGreaterThan(self::TIMEOUT * ($emits - 1), $time * 1000);
     }
 
     /**


### PR DESCRIPTION
Previously, backpressure was only released once advance() was called again. This means the last backpressure item was never free'd in case the caller knows there are no more items to consume and didn't call advance() the last time.