### PR TITLE
Add Loop::isRunning()

### DIFF
--- a/lib/Loop.php
+++ b/lib/Loop.php
@@ -109,6 +109,16 @@ final class Loop
     }
 
     /**
+     * Returns true if the event loop is running, false if it is stopped.
+     *
+     * @return bool True if the event loop is running, false if it is stopped.
+     */
+    public static function isRunning(): bool
+    {
+        return self::$driver->isRunning();
+    }
+
+    /**
      * Defer the execution of a callback.
      *
      * The deferred callable MUST be executed before any other type of watcher in a tick. Order of enabling MUST be

--- a/lib/Loop/Driver.php
+++ b/lib/Loop/Driver.php
@@ -77,6 +77,14 @@ abstract class Driver
     }
 
     /**
+     * @return bool True if the event loop is running, false if it is stopped.
+     */
+    public function isRunning(): bool
+    {
+        return $this->running;
+    }
+
+    /**
      * @return bool True if no enabled and referenced watchers remain in the loop.
      */
     private function isEmpty(): bool

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -2,7 +2,6 @@
 
 namespace Amp
 {
-
     use React\Promise\PromiseInterface as ReactPromise;
 
     /**
@@ -129,7 +128,6 @@ namespace Amp
 
 namespace Amp\Promise
 {
-
     use Amp\Deferred;
     use Amp\Loop;
     use Amp\MultiReasonException;
@@ -175,9 +173,11 @@ namespace Amp\Promise
      * Use this function only in synchronous contexts to wait for an asynchronous operation. Use coroutines and yield to
      * await promise resolution in a fully asynchronous application instead.
      *
-     * @param Promise|ReactPromise $promise Promise to wait for.
+     * @template TReturn
      *
-     * @return mixed Promise success value.
+     * @param Promise<TReturn>|ReactPromise $promise Promise to wait for.
+     *
+     * @return TReturn Promise success value.
      *
      * @throws \TypeError If $promise is not an instance of \Amp\Promise or \React\Promise\PromiseInterface.
      * @throws \Error If the event loop stopped without the $promise being resolved.
@@ -185,6 +185,10 @@ namespace Amp\Promise
      */
     function wait($promise)
     {
+        if (Loop::isRunning()) {
+            throw new \Error("Cannot call " . __FUNCTION__ . "() within a running event loop");
+        }
+
         if (!$promise instanceof Promise) {
             if ($promise instanceof ReactPromise) {
                 $promise = adapt($promise);
@@ -553,7 +557,6 @@ namespace Amp\Promise
 
 namespace Amp\Iterator
 {
-
     use Amp\Delayed;
     use Amp\Emitter;
     use Amp\Iterator;

--- a/test/WaitTest.php
+++ b/test/WaitTest.php
@@ -45,15 +45,13 @@ class WaitTest extends BaseTest
      */
     public function testWaitOnPendingPromise()
     {
-        Loop::run(function () {
-            $value = 1;
+        $value = 1;
 
-            $promise = new Delayed(100, $value);
+        $promise = new Delayed(100, $value);
 
-            $result = Promise\wait($promise);
+        $result = Promise\wait($promise);
 
-            $this->assertSame($value, $result);
-        });
+        $this->assertSame($value, $result);
     }
 
     /**
@@ -96,5 +94,15 @@ class WaitTest extends BaseTest
     {
         $this->expectException(\TypeError::class);
         Promise\wait(42);
+    }
+
+    public function testWithinRunningEventLoop()
+    {
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Cannot call');
+
+        Loop::run(function () {
+            Promise\wait(new Success);
+        });
     }
 }


### PR DESCRIPTION
`Amp\Promise\wait()` now fails if called within a running event loop, which has always been a mistake anyway.