### PR TITLE
Allow nested calls to Amp\Promise\wait

### DIFF
--- a/lib/Loop/DelegateLoop.php
+++ b/lib/Loop/DelegateLoop.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Amp\Loop;
+
+final class DelegateLoop
+{
+    private $run;
+    private $stop;
+
+    public function __construct(callable $run, callable $stop)
+    {
+        $this->run = $run;
+        $this->stop = $stop;
+    }
+
+    public function run()
+    {
+        ($this->run)();
+    }
+
+    public function stop()
+    {
+        ($this->stop)();
+    }
+}

--- a/lib/Loop/Driver.php
+++ b/lib/Loop/Driver.php
@@ -87,21 +87,37 @@ abstract class Driver
      */
     public function createControl(): DriverControl
     {
-        return new DriverControl(
-            function () use (&$running) {
-                $running = true;
-                while ($running) {
-                    if ($this->isEmpty()) {
-                        return;
-                    }
-
-                    $this->tick();
+        return new class(function () use (&$running) {
+            $running = true;
+            while ($running) {
+                if ($this->isEmpty()) {
+                    return;
                 }
-            },
-            static function () use (&$running) {
-                $running = false;
+
+                $this->tick();
             }
-        );
+        }, static function () use (&$running) {
+            $running = false;
+        }) implements DriverControl {
+            private $run;
+            private $stop;
+
+            public function __construct(callable $run, callable $stop)
+            {
+                $this->run = $run;
+                $this->stop = $stop;
+            }
+
+            public function run()
+            {
+                ($this->run)();
+            }
+
+            public function stop()
+            {
+                ($this->stop)();
+            }
+        };
     }
 
     /**

--- a/lib/Loop/Driver.php
+++ b/lib/Loop/Driver.php
@@ -79,11 +79,13 @@ abstract class Driver
     /**
      * Run the event loop with an explicit stop handle.
      *
-     * This method is intended for Amp\Promise\wait only and NOT exposed as method in Amp\Loop.
+     * This method is intended for {@see \Amp\Promise\wait()} only and NOT exposed as method in {@see \Amp\Loop}.
+     *
+     * @param callable $callback Callback is given a callable as the only parameter that is used to stop the event loop.
      *
      * @return void
-     * @see Driver::run()
      *
+     * @see Driver::run()
      */
     public function execute(callable $callback)
     {

--- a/lib/Loop/Driver.php
+++ b/lib/Loop/Driver.php
@@ -77,17 +77,17 @@ abstract class Driver
     }
 
     /**
-     * Run the event loop with an explicit stop handle.
+     * Create a control that can be used to start and stop a specific iteration of the driver loop.
      *
      * This method is intended for {@see \Amp\Promise\wait()} only and NOT exposed as method in {@see \Amp\Loop}.
      *
-     * @return DelegateLoop
+     * @return DriverControl
      *
      * @see Driver::run()
      */
-    public function delegate(): DelegateLoop
+    public function createControl(): DriverControl
     {
-        return new DelegateLoop(
+        return new DriverControl(
             function () use (&$running) {
                 $running = true;
                 while ($running) {

--- a/lib/Loop/Driver.php
+++ b/lib/Loop/Driver.php
@@ -81,27 +81,27 @@ abstract class Driver
      *
      * This method is intended for {@see \Amp\Promise\wait()} only and NOT exposed as method in {@see \Amp\Loop}.
      *
-     * @param callable $callback Callback is given a callable as the only parameter that is used to stop the event loop.
-     *
-     * @return void
+     * @return DelegateLoop
      *
      * @see Driver::run()
      */
-    public function execute(callable $callback)
+    public function delegate(): DelegateLoop
     {
-        $running = true;
+        return new DelegateLoop(
+            function () use (&$running) {
+                $running = true;
+                while ($running) {
+                    if ($this->isEmpty()) {
+                        return;
+                    }
 
-        $callback(static function () use (&$running) {
-            $running = false;
-        });
-
-        while ($running) {
-            if ($this->isEmpty()) {
-                return;
+                    $this->tick();
+                }
+            },
+            static function () use (&$running) {
+                $running = false;
             }
-
-            $this->tick();
-        }
+        );
     }
 
     /**

--- a/lib/Loop/DriverControl.php
+++ b/lib/Loop/DriverControl.php
@@ -2,7 +2,7 @@
 
 namespace Amp\Loop;
 
-final class DelegateLoop
+final class DriverControl
 {
     private $run;
     private $stop;

--- a/lib/Loop/DriverControl.php
+++ b/lib/Loop/DriverControl.php
@@ -2,24 +2,23 @@
 
 namespace Amp\Loop;
 
-final class DriverControl
+interface DriverControl
 {
-    private $run;
-    private $stop;
+    /**
+     * Run the driver event loop.
+     *
+     * @return void
+     *
+     * @see Driver::run()
+     */
+    public function run();
 
-    public function __construct(callable $run, callable $stop)
-    {
-        $this->run = $run;
-        $this->stop = $stop;
-    }
-
-    public function run()
-    {
-        ($this->run)();
-    }
-
-    public function stop()
-    {
-        ($this->stop)();
-    }
+    /**
+     * Stop the driver event loop.
+     *
+     * @return void
+     *
+     * @see Driver::stop()
+     */
+    public function stop();
 }

--- a/lib/Loop/TracingDriver.php
+++ b/lib/Loop/TracingDriver.php
@@ -27,9 +27,9 @@ final class TracingDriver extends Driver
         $this->driver->run();
     }
 
-    public function execute(callable $callback)
+    public function delegate(): DelegateLoop
     {
-        $this->driver->execute($callback);
+        return $this->driver->delegate();
     }
 
     public function stop()

--- a/lib/Loop/TracingDriver.php
+++ b/lib/Loop/TracingDriver.php
@@ -27,6 +27,11 @@ final class TracingDriver extends Driver
         $this->driver->run();
     }
 
+    public function execute(callable $callback)
+    {
+        $this->driver->execute($callback);
+    }
+
     public function stop()
     {
         $this->driver->stop();

--- a/lib/Loop/TracingDriver.php
+++ b/lib/Loop/TracingDriver.php
@@ -27,9 +27,9 @@ final class TracingDriver extends Driver
         $this->driver->run();
     }
 
-    public function delegate(): DelegateLoop
+    public function createControl(): DriverControl
     {
-        return $this->driver->delegate();
+        return $this->driver->createControl();
     }
 
     public function stop()

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -175,9 +175,11 @@ namespace Amp\Promise
      * Use this function only in synchronous contexts to wait for an asynchronous operation. Use coroutines and yield to
      * await promise resolution in a fully asynchronous application instead.
      *
-     * @param Promise|ReactPromise $promise Promise to wait for.
+     * @template TReturn
      *
-     * @return mixed Promise success value.
+     * @param Promise<TReturn>|ReactPromise $promise Promise to wait for.
+     *
+     * @return TReturn Promise success value.
      *
      * @throws \TypeError If $promise is not an instance of \Amp\Promise or \React\Promise\PromiseInterface.
      * @throws \Error If the event loop stopped without the $promise being resolved.

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -196,9 +196,11 @@ namespace Amp\Promise
         $resolved = false;
 
         try {
-            Loop::run(function () use (&$resolved, &$value, &$exception, $promise) {
-                $promise->onResolve(function ($e, $v) use (&$resolved, &$value, &$exception) {
-                    Loop::stop();
+            $driver = Loop::get();
+            $driver->execute(static function (callable $stop) use (&$resolved, &$value, &$exception, $promise) {
+                $promise->onResolve(static function ($e, $v) use (&$resolved, &$value, &$exception, $stop) {
+                    $stop();
+
                     $resolved = true;
                     $exception = $e;
                     $value = $v;

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -199,15 +199,17 @@ namespace Amp\Promise
 
         try {
             $driver = Loop::get();
-            $driver->execute(static function (callable $stop) use (&$resolved, &$value, &$exception, $promise) {
-                $promise->onResolve(static function ($e, $v) use (&$resolved, &$value, &$exception, $stop) {
-                    $stop();
+            $delegate = $driver->delegate();
 
-                    $resolved = true;
-                    $exception = $e;
-                    $value = $v;
-                });
+            $promise->onResolve(static function ($e, $v) use (&$resolved, &$value, &$exception, $delegate) {
+                $delegate->stop();
+
+                $resolved = true;
+                $exception = $e;
+                $value = $v;
             });
+
+            $delegate->run();
         } catch (\Throwable $throwable) {
             throw new \Error("Loop exceptionally stopped without resolving the promise", 0, $throwable);
         }

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -199,17 +199,17 @@ namespace Amp\Promise
 
         try {
             $driver = Loop::get();
-            $delegate = $driver->delegate();
+            $control = $driver->createControl();
 
-            $promise->onResolve(static function ($e, $v) use (&$resolved, &$value, &$exception, $delegate) {
-                $delegate->stop();
+            $promise->onResolve(static function ($e, $v) use (&$resolved, &$value, &$exception, $control) {
+                $control->stop();
 
                 $resolved = true;
                 $exception = $e;
                 $value = $v;
             });
 
-            $delegate->run();
+            $control->run();
         } catch (\Throwable $throwable) {
             throw new \Error("Loop exceptionally stopped without resolving the promise", 0, $throwable);
         }


### PR DESCRIPTION
This is an improved implementation for #309 that doesn't suffer from the same problems and has improved BC, because normal nested `Loop::run()` calls are unaffected. The only change needed that's slightly breaking is if a custom driver was implemented that delegates all methods like `TracingDriver`.

This implementation could also be used by Symfony's HTTP client, which does have [something similar to `Amp\Promise\wait`](https://github.com/symfony/http-client/blob/3846a7fceb2c7e6c05f8edd1bd999a2f6be89623/Response/AmpResponse.php#L167-L181).

We could change the callable to a proper object to improve typing.