### PR TITLE
Allow nested calls to Amp\Promise\wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
   - php vendor/bin/phpunit --verbose --group memoryleak
   - php vendor/bin/phpunit --verbose --exclude-group memoryleak --coverage-php coverage/cov/main.cov
   - PHP_CS_FIXER_IGNORE_ENV=1 php vendor/bin/php-cs-fixer --diff --dry-run -v fix
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then echo "Skipped psalm static analysis"; else vendor/bin/psalm; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then echo "Skipped psalm static analysis"; else vendor/bin/psalm --shepherd; fi
 
 after_script:
   - curl -OL https://github.com/php-coveralls/php-coveralls/releases/download/v1.0.0/coveralls.phar

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -214,16 +214,17 @@ namespace Amp\Promise
         $resolved = false;
 
         try {
-            do {
-                Loop::run(function () use (&$resolved, &$value, &$exception, $promise) {
-                    $promise->onResolve(function ($e, $v) use (&$resolved, &$value, &$exception) {
-                        Loop::stop();
-                        $resolved = true;
-                        $exception = $e;
-                        $value = $v;
-                    });
-                });
-            } while (!$resolved && Loop::getInfo()['enabled_watchers']['referenced'] > 0);
+            $promise->onResolve(function ($e, $v) use (&$resolved, &$value, &$exception) {
+                Loop::stop();
+
+                $resolved = true;
+                $exception = $e;
+                $value = $v;
+            });
+
+            while (!$resolved && Loop::getInfo()['enabled_watchers']['referenced'] > 0) {
+                Loop::run();
+            }
         } catch (\Throwable $throwable) {
             throw new \Error("Loop exceptionally stopped without resolving the promise", 0, $throwable);
         }

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -212,15 +212,20 @@ namespace Amp\Promise
         }
 
         $resolved = false;
+        $running = false;
 
         try {
-            $promise->onResolve(function ($e, $v) use (&$resolved, &$value, &$exception) {
-                Loop::stop();
+            $promise->onResolve(function ($e, $v) use (&$resolved, &$value, &$exception, &$running) {
+                if ($running) {
+                    Loop::stop();
+                }
 
                 $resolved = true;
                 $exception = $e;
                 $value = $v;
             });
+
+            $running = true;
 
             while (!$resolved && Loop::getInfo()['enabled_watchers']['referenced'] > 0) {
                 Loop::run();

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -214,14 +214,16 @@ namespace Amp\Promise
         $resolved = false;
 
         try {
-            Loop::run(function () use (&$resolved, &$value, &$exception, $promise) {
-                $promise->onResolve(function ($e, $v) use (&$resolved, &$value, &$exception) {
-                    Loop::stop();
-                    $resolved = true;
-                    $exception = $e;
-                    $value = $v;
+            do {
+                Loop::run(function () use (&$resolved, &$value, &$exception, $promise) {
+                    $promise->onResolve(function ($e, $v) use (&$resolved, &$value, &$exception) {
+                        Loop::stop();
+                        $resolved = true;
+                        $exception = $e;
+                        $value = $v;
+                    });
                 });
-            });
+            } while (!$resolved && Loop::getInfo()['enabled_watchers']['referenced'] > 0);
         } catch (\Throwable $throwable) {
             throw new \Error("Loop exceptionally stopped without resolving the promise", 0, $throwable);
         }


### PR DESCRIPTION
Compared to #311, this doesn't break BC at all, because we previously threw an `\Error` in this case, which indicates a programming error and not valid runtime behavior.