### PR TITLE
Allow signal handling for Uv w/o 100% cpu usage

### DIFF
--- a/examples/event-loop/signals.php
+++ b/examples/event-loop/signals.php
@@ -7,18 +7,10 @@ use Amp\Loop;
 
 print "Press Ctrl+C to exit..." . PHP_EOL;
 
-Loop::onSignal(SIGINT, function () {
+Loop::onSignal(SIGINT, function ($watcherId) {
     print "Caught SIGINT, exiting..." . PHP_EOL;
     
-    // Check for a Uv driver
-    if (Loop::get() instanceof Amp\Loop\UvDriver) {
-
-        // Stop the loop
-        Loop::stop();
-
-        // Cannot exit out of a UvDriver loop here, can only stop the loop
-        return;
-    }
+    Loop::cancel($watcherId);
     
     exit(0);
 });

--- a/examples/event-loop/signals.php
+++ b/examples/event-loop/signals.php
@@ -9,7 +9,20 @@ print "Press Ctrl+C to exit..." . PHP_EOL;
 
 Loop::onSignal(SIGINT, function () {
     print "Caught SIGINT, exiting..." . PHP_EOL;
+    
+    // Check for a Uv driver
+    if (Loop::get() instanceof Amp\Loop\UvDriver) {
+
+        // Stop the loop
+        Loop::stop();
+
+        // Cannot exit out of a UvDriver loop here, can only stop the loop
+        return;
+    }
+    
     exit(0);
 });
 
 Loop::run();
+
+exit(0);


### PR DESCRIPTION
Ref #329

To be honest this could lend itself to its own `Uv` specific example file, but here's something that could work regardless of driver used.

Again, downside is that the end of code execution is not in the signal handling function, but sometime after the `Loop::run()` line.