### PR TITLE
Ignore only stream_select errors due to signal interruptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
 script:
   # Run testNoMemoryLeak separately, as those are skipped with enabled coverage
   - php vendor/bin/phpunit --verbose --group memoryleak
-  - php vendor/bin/phpunit --verbose --exclude-group memoryleak --coverage-php coverage/cov/main.cov
+  - php -dxdebug.mode=coverage vendor/bin/phpunit --verbose --exclude-group memoryleak --coverage-php coverage/cov/main.cov
   - PHP_CS_FIXER_IGNORE_ENV=1 php vendor/bin/php-cs-fixer --diff --dry-run -v fix
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then echo "Skipped psalm static analysis"; else vendor/bin/psalm.phar; fi
 

--- a/lib/Loop/NativeDriver.php
+++ b/lib/Loop/NativeDriver.php
@@ -296,14 +296,14 @@ class NativeDriver extends Driver
                 \restore_error_handler();
             }
 
-            if ($this->streamSelectIgnoreResult) {
+            if ($this->streamSelectIgnoreResult || $result === 0) {
                 $this->streamSelectIgnoreResult = false;
-            } elseif (!$result) {
-                if ($result === 0) {
-                    return;
-                }
+                return;
+            }
 
+            if (!$result) {
                 $this->error(new \Exception('Unknown error during stream_select'));
+                return;
             }
 
             foreach ($read as $stream) {

--- a/lib/Loop/NativeDriver.php
+++ b/lib/Loop/NativeDriver.php
@@ -40,6 +40,11 @@ class NativeDriver extends Driver
     /** @var bool */
     private $signalHandling;
 
+    /** @var callable */
+    private $streamSelectErrorHandler;
+
+    private $streamSelectIgnoreResult = false;
+
     public function __construct()
     {
         $this->timerQueue = new Internal\TimerQueue;
@@ -47,6 +52,31 @@ class NativeDriver extends Driver
         $this->nowOffset = getCurrentTime();
         $this->now = \random_int(0, $this->nowOffset);
         $this->nowOffset -= $this->now;
+        $this->streamSelectErrorHandler = function ($errno, $message) {
+            // Casing changed in PHP 8 from 'unable' to 'Unable'
+            if (\stripos($message, "stream_select(): unable to select [4]: ") === 0) { // EINTR
+                $this->streamSelectIgnoreResult = true;
+
+                return;
+            }
+
+            if (\strpos($message, 'FD_SETSIZE') !== false) {
+                $message = \str_replace(["\r\n", "\n", "\r"], " ", $message);
+                $pattern = '(stream_select\(\): You MUST recompile PHP with a larger value of FD_SETSIZE. It is set to (\d+), but you have descriptors numbered at least as high as (\d+)\.)';
+
+                if (\preg_match($pattern, $message, $match)) {
+                    $helpLink = 'https://amphp.org/amp/event-loop/#implementations';
+
+                    $message = 'You have reached the limits of stream_select(). It has a FD_SETSIZE of ' . $match[1]
+                        . ', but you have file descriptors numbered at least as high as ' . $match[2] . '.'
+                        . "You can install one of the extensions listed on {$helpLink} to support a higher number of "
+                        . "concurrent file descriptors. If a large number of open file descriptors is unexpected, you "
+                        . "might be leaking file descriptors that aren't closed correctly.";
+                }
+            }
+
+            throw new \Exception($message, $errno);
+        };
     }
 
     /**
@@ -129,131 +159,6 @@ class NativeDriver extends Driver
         if ($this->signalHandling) {
             \pcntl_signal_dispatch();
         }
-    }
-
-    /**
-     * @param resource[] $read
-     * @param resource[] $write
-     * @param int        $timeout
-     *
-     * @return void
-     */
-    private function selectStreams(array $read, array $write, int $timeout)
-    {
-        $timeout /= self::MILLISEC_PER_SEC;
-
-        if (!empty($read) || !empty($write)) { // Use stream_select() if there are any streams in the loop.
-            if ($timeout >= 0) {
-                $seconds = (int) $timeout;
-                $microseconds = (int) (($timeout - $seconds) * self::MICROSEC_PER_SEC);
-            } else {
-                $seconds = null;
-                $microseconds = null;
-            }
-
-            $except = null;
-
-            // Error reporting suppressed since stream_select() emits an E_WARNING if it is interrupted by a signal.
-            if (!($result = @\stream_select($read, $write, $except, $seconds, $microseconds))) {
-                if ($result === 0) {
-                    return;
-                }
-
-                $error = \error_get_last();
-
-                if (\strpos($error["message"] ?? '', "unable to select") !== 0) {
-                    return;
-                }
-
-                $this->error(new \Exception($error["message"] ?? 'Unknown error during stream_select'));
-            }
-
-            foreach ($read as $stream) {
-                $streamId = (int) $stream;
-                if (!isset($this->readWatchers[$streamId])) {
-                    continue; // All read watchers disabled.
-                }
-
-                foreach ($this->readWatchers[$streamId] as $watcher) {
-                    if (!isset($this->readWatchers[$streamId][$watcher->id])) {
-                        continue; // Watcher disabled by another IO watcher.
-                    }
-
-                    try {
-                        $result = ($watcher->callback)($watcher->id, $stream, $watcher->data);
-
-                        if ($result === null) {
-                            continue;
-                        }
-
-                        if ($result instanceof \Generator) {
-                            $result = new Coroutine($result);
-                        }
-
-                        if ($result instanceof Promise || $result instanceof ReactPromise) {
-                            rethrow($result);
-                        }
-                    } catch (\Throwable $exception) {
-                        $this->error($exception);
-                    }
-                }
-            }
-
-            \assert(\is_array($write)); // See https://github.com/vimeo/psalm/issues/3036
-
-            foreach ($write as $stream) {
-                $streamId = (int) $stream;
-                if (!isset($this->writeWatchers[$streamId])) {
-                    continue; // All write watchers disabled.
-                }
-
-                foreach ($this->writeWatchers[$streamId] as $watcher) {
-                    if (!isset($this->writeWatchers[$streamId][$watcher->id])) {
-                        continue; // Watcher disabled by another IO watcher.
-                    }
-
-                    try {
-                        $result = ($watcher->callback)($watcher->id, $stream, $watcher->data);
-
-                        if ($result === null) {
-                            continue;
-                        }
-
-                        if ($result instanceof \Generator) {
-                            $result = new Coroutine($result);
-                        }
-
-                        if ($result instanceof Promise || $result instanceof ReactPromise) {
-                            rethrow($result);
-                        }
-                    } catch (\Throwable $exception) {
-                        $this->error($exception);
-                    }
-                }
-            }
-
-            return;
-        }
-
-        if ($timeout > 0) { // Otherwise sleep with usleep() if $timeout > 0.
-            \usleep((int) ($timeout * self::MICROSEC_PER_SEC));
-        }
-    }
-
-    /**
-     * @return int Milliseconds until next timer expires or -1 if there are no pending times.
-     */
-    private function getTimeout(): int
-    {
-        $expiration = $this->timerQueue->peek();
-
-        if ($expiration === null) {
-            return -1;
-        }
-
-        $expiration -= getCurrentTime() - $this->nowOffset;
-
-        return $expiration > 0 ? $expiration : 0;
     }
 
     /**
@@ -358,6 +263,134 @@ class NativeDriver extends Driver
                 throw new \Error("Unknown watcher type");
             // @codeCoverageIgnoreEnd
         }
+    }
+
+    /**
+     * @param resource[] $read
+     * @param resource[] $write
+     * @param int        $timeout
+     *
+     * @return void
+     */
+    private function selectStreams(array $read, array $write, int $timeout)
+    {
+        $timeout /= self::MILLISEC_PER_SEC;
+
+        if (!empty($read) || !empty($write)) { // Use stream_select() if there are any streams in the loop.
+            if ($timeout >= 0) {
+                $seconds = (int) $timeout;
+                $microseconds = (int) (($timeout - $seconds) * self::MICROSEC_PER_SEC);
+            } else {
+                $seconds = null;
+                $microseconds = null;
+            }
+
+            $except = null;
+
+            \set_error_handler($this->streamSelectErrorHandler);
+
+            try {
+                $result = \stream_select($read, $write, $except, $seconds, $microseconds);
+            } finally {
+                \restore_error_handler();
+            }
+
+            if ($this->streamSelectIgnoreResult) {
+                $this->streamSelectIgnoreResult = false;
+            } elseif (!$result) {
+                if ($result === 0) {
+                    return;
+                }
+
+                $this->error(new \Exception('Unknown error during stream_select'));
+            }
+
+            foreach ($read as $stream) {
+                $streamId = (int) $stream;
+                if (!isset($this->readWatchers[$streamId])) {
+                    continue; // All read watchers disabled.
+                }
+
+                foreach ($this->readWatchers[$streamId] as $watcher) {
+                    if (!isset($this->readWatchers[$streamId][$watcher->id])) {
+                        continue; // Watcher disabled by another IO watcher.
+                    }
+
+                    try {
+                        $result = ($watcher->callback)($watcher->id, $stream, $watcher->data);
+
+                        if ($result === null) {
+                            continue;
+                        }
+
+                        if ($result instanceof \Generator) {
+                            $result = new Coroutine($result);
+                        }
+
+                        if ($result instanceof Promise || $result instanceof ReactPromise) {
+                            rethrow($result);
+                        }
+                    } catch (\Throwable $exception) {
+                        $this->error($exception);
+                    }
+                }
+            }
+
+            \assert(\is_array($write)); // See https://github.com/vimeo/psalm/issues/3036
+
+            foreach ($write as $stream) {
+                $streamId = (int) $stream;
+                if (!isset($this->writeWatchers[$streamId])) {
+                    continue; // All write watchers disabled.
+                }
+
+                foreach ($this->writeWatchers[$streamId] as $watcher) {
+                    if (!isset($this->writeWatchers[$streamId][$watcher->id])) {
+                        continue; // Watcher disabled by another IO watcher.
+                    }
+
+                    try {
+                        $result = ($watcher->callback)($watcher->id, $stream, $watcher->data);
+
+                        if ($result === null) {
+                            continue;
+                        }
+
+                        if ($result instanceof \Generator) {
+                            $result = new Coroutine($result);
+                        }
+
+                        if ($result instanceof Promise || $result instanceof ReactPromise) {
+                            rethrow($result);
+                        }
+                    } catch (\Throwable $exception) {
+                        $this->error($exception);
+                    }
+                }
+            }
+
+            return;
+        }
+
+        if ($timeout > 0) { // Otherwise sleep with usleep() if $timeout > 0.
+            \usleep((int) ($timeout * self::MICROSEC_PER_SEC));
+        }
+    }
+
+    /**
+     * @return int Milliseconds until next timer expires or -1 if there are no pending times.
+     */
+    private function getTimeout(): int
+    {
+        $expiration = $this->timerQueue->peek();
+
+        if ($expiration === null) {
+            return -1;
+        }
+
+        $expiration -= getCurrentTime() - $this->nowOffset;
+
+        return $expiration > 0 ? $expiration : 0;
     }
 
     /**

--- a/lib/Loop/NativeDriver.php
+++ b/lib/Loop/NativeDriver.php
@@ -68,7 +68,7 @@ class NativeDriver extends Driver
                     $helpLink = 'https://amphp.org/amp/event-loop/#implementations';
 
                     $message = 'You have reached the limits of stream_select(). It has a FD_SETSIZE of ' . $match[1]
-                        . ', but you have file descriptors numbered at least as high as ' . $match[2] . '.'
+                        . ', but you have file descriptors numbered at least as high as ' . $match[2] . '. '
                         . "You can install one of the extensions listed on {$helpLink} to support a higher number of "
                         . "concurrent file descriptors. If a large number of open file descriptors is unexpected, you "
                         . "might be leaking file descriptors that aren't closed correctly.";

--- a/lib/Loop/NativeDriver.php
+++ b/lib/Loop/NativeDriver.php
@@ -43,6 +43,7 @@ class NativeDriver extends Driver
     /** @var callable */
     private $streamSelectErrorHandler;
 
+    /** @var bool */
     private $streamSelectIgnoreResult = false;
 
     public function __construct()

--- a/test/Loop/NativeDriverTest.php
+++ b/test/Loop/NativeDriverTest.php
@@ -19,6 +19,66 @@ class NativeDriverTest extends DriverTest
         $this->assertNull($this->loop->getHandle());
     }
 
+    public function testTooLargeFileDescriptorSet()
+    {
+        $sockets = [];
+        $domain = \stripos(PHP_OS, 'win') === 0 ? STREAM_PF_INET : STREAM_PF_UNIX;
+
+        for ($i = 0; $i < 1001; $i++) {
+            $sockets[] = \stream_socket_pair($domain, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+        }
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("You have reached the limits of stream_select(). It has a FD_SETSIZE of 1024, but you have file descriptors numbered at least as high as 2006.You can install one of the extensions listed on https://amphp.org/amp/event-loop/#implementations to support a higher number of concurrent file descriptors. If a large number of open file descriptors is unexpected, you might be leaking file descriptors that aren't closed correctly.");
+
+        $this->start(function (Driver $loop) use ($sockets) {
+            $loop->delay(100, function () {
+                // here to provide timeout to stream_select, as the warning is only issued after the system call returns
+            });
+
+            foreach ($sockets as [$left, $right]) {
+                $loop->onReadable($left, function () {
+                    // nothing
+                });
+
+                $loop->onReadable($right, function () {
+                    // nothing
+                });
+            }
+        });
+    }
+
+    public function testSignalDuringStreamSelectIgnored()
+    {
+        $domain = \stripos(PHP_OS, 'win') === 0 ? STREAM_PF_INET : STREAM_PF_UNIX;
+        $sockets = \stream_socket_pair($domain, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+
+        $this->start(function (Driver $loop) use ($sockets) {
+            $socketWatchers = [
+                $loop->onReadable($sockets[0], function () {
+                    // nothing
+                }),
+                $loop->onReadable($sockets[1], function () {
+                    // nothing
+                }),
+            ];
+
+            $loop->onSignal(\SIGUSR2, function ($signalWatcher) use ($socketWatchers, $loop) {
+                $loop->cancel($signalWatcher);
+
+                foreach ($socketWatchers as $watcher) {
+                    $loop->cancel($watcher);
+                }
+
+                $this->assertTrue(true);
+            });
+
+            $loop->delay(100, function () {
+                \proc_open('sh -c "sleep 1; kill -12 ' . \getmypid() . '"', [], $pipes);
+            });
+        });
+    }
+
     /**
      * @requires PHP 7.1
      */
@@ -28,7 +88,7 @@ class NativeDriverTest extends DriverTest
 
         try {
             $this->start(function (Driver $loop) use (&$invoked) {
-                $watcher = $loop->onSignal(SIGUSR1, function () use (&$invoked) {
+                $watcher = $loop->onSignal(\SIGUSR1, function () use (&$invoked) {
                     $invoked = true;
                 });
                 $loop->unreference($watcher);

--- a/test/Loop/NativeDriverTest.php
+++ b/test/Loop/NativeDriverTest.php
@@ -74,7 +74,7 @@ class NativeDriverTest extends DriverTest
             });
 
             $loop->delay(100, function () {
-                \proc_open('sh -c "sleep 1; kill -12 ' . \getmypid() . '"', [], $pipes);
+                \proc_open('bash -c "sleep 1; kill -12 ' . \getmypid() . '"', [], $pipes);
             });
         });
     }

--- a/test/Loop/NativeDriverTest.php
+++ b/test/Loop/NativeDriverTest.php
@@ -29,7 +29,7 @@ class NativeDriverTest extends DriverTest
         }
 
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage("You have reached the limits of stream_select(). It has a FD_SETSIZE of 1024, but you have file descriptors numbered at least as high as 2006. You can install one of the extensions listed on https://amphp.org/amp/event-loop/#implementations to support a higher number of concurrent file descriptors. If a large number of open file descriptors is unexpected, you might be leaking file descriptors that aren't closed correctly.");
+        $this->expectExceptionMessage("You have reached the limits of stream_select(). It has a FD_SETSIZE of 1024, but you have file descriptors numbered at least as high as 200");
 
         $this->start(function (Driver $loop) use ($sockets) {
             $loop->delay(100, function () {

--- a/test/Loop/NativeDriverTest.php
+++ b/test/Loop/NativeDriverTest.php
@@ -29,7 +29,7 @@ class NativeDriverTest extends DriverTest
         }
 
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage("You have reached the limits of stream_select(). It has a FD_SETSIZE of 1024, but you have file descriptors numbered at least as high as 2006.You can install one of the extensions listed on https://amphp.org/amp/event-loop/#implementations to support a higher number of concurrent file descriptors. If a large number of open file descriptors is unexpected, you might be leaking file descriptors that aren't closed correctly.");
+        $this->expectExceptionMessage("You have reached the limits of stream_select(). It has a FD_SETSIZE of 1024, but you have file descriptors numbered at least as high as 2006. You can install one of the extensions listed on https://amphp.org/amp/event-loop/#implementations to support a higher number of concurrent file descriptors. If a large number of open file descriptors is unexpected, you might be leaking file descriptors that aren't closed correctly.");
 
         $this->start(function (Driver $loop) use ($sockets) {
             $loop->delay(100, function () {

--- a/test/Loop/NativeDriverTest.php
+++ b/test/Loop/NativeDriverTest.php
@@ -74,7 +74,7 @@ class NativeDriverTest extends DriverTest
             });
 
             $loop->delay(100, function () {
-                \proc_open('bash -c "sleep 1; kill -12 ' . \getmypid() . '"', [], $pipes);
+                \proc_open('sh -c "sleep 1; kill -USR2 ' . \getmypid() . '"', [], $pipes);
             });
         });
     }

--- a/test/Loop/NativeDriverTest.php
+++ b/test/Loop/NativeDriverTest.php
@@ -36,7 +36,7 @@ class NativeDriverTest extends DriverTest
                 // here to provide timeout to stream_select, as the warning is only issued after the system call returns
             });
 
-            foreach ($sockets as [$left, $right]) {
+            foreach ($sockets as list($left, $right)) {
                 $loop->onReadable($left, function () {
                     // nothing
                 });

--- a/travis/install-uv.sh
+++ b/travis/install-uv.sh
@@ -3,7 +3,7 @@
 set -e
 
 wget https://github.com/libuv/libuv/archive/v1.24.1.tar.gz -O /tmp/libuv.tar.gz -q &
-wget https://github.com/bwoebi/php-uv/archive/master.tar.gz -O /tmp/php-uv.tar.gz -q &
+wget https://github.com/bwoebi/php-uv/archive/444acfb9636094c2c96d1e7b43332027f464efc5.tar.gz -O /tmp/php-uv.tar.gz -q &
 wait
 
 mkdir libuv && tar -xf /tmp/libuv.tar.gz -C libuv --strip-components=1


### PR DESCRIPTION
This also fixes signal interruptions not being ignored on PHP 8, as the error message changed slightly.

Fixes #265.