### PR TITLE
Fix TypeError in EventDriver

### DIFF
--- a/lib/Loop/EventDriver.php
+++ b/lib/Loop/EventDriver.php
@@ -144,9 +144,9 @@ final class EventDriver extends DriverFoundation
 
         // Manually free the loop handle to fully release loop resources.
         // See https://github.com/amphp/amp/issues/177.
-        if ($this->handle !== null) {
+        if (isset($this->handle)) {
             $this->handle->free();
-            $this->handle = null;
+            unset($this->handle);
         }
     }
 


### PR DESCRIPTION
Fixes

```
PHP Fatal error:  Uncaught TypeError: Cannot assign null to property Amp\Loop\EventDriver::$handle of type EventBase in .../lib/Loop/EventDriver.php:149
Stack trace:
#0 [internal function]: Amp\Loop\EventDriver->__destruct()
#1 {main}
  thrown in .../lib/Loop/EventDriver.php on line 149
```