### PR TITLE
Increase EventDriver::__destruct robustness

### DIFF
--- a/lib/Loop/EventDriver.php
+++ b/lib/Loop/EventDriver.php
@@ -168,7 +168,7 @@ class EventDriver extends Driver
         // Related https://github.com/amphp/amp/issues/159.
         $events = $this->events;
         $this->events = [];
-        
+
         foreach ($events as $event) {
             if ($event !== null) { // Events may have been nulled in extension depending on destruct order.
                 $event->free();


### PR DESCRIPTION
We ran into `E_WARNING`s on PHP8: `Event::del(): Failed deletting event in /code/vendor/amphp/amp/lib/Loop/EventDriver.php (Line 355)`  with the following stacktrace

```
[#1] *internal error-handling*
[#2] *internal error-handling*
[#3] *internal error-handling*
[#4] *internal error-handling*
[#5] Event->del in /code/vendor/amphp/amp/lib/Loop/EventDriver.php on line 355
[#6] Amp\Loop\EventDriver->deactivate in /code/vendor/amphp/amp/lib/Loop/Driver.php on line 486
[#7] Amp\Loop\Driver->disable in /code/vendor/amphp/amp/lib/Loop/Driver.php on line 439
[#8] Amp\Loop\Driver->cancel in /code/vendor/amphp/amp/lib/Loop/EventDriver.php on line 149
[#9] Amp\Loop\EventDriver->cancel in /code/lib/Sensphere/Amp/Loop/DecoratableDriver.php on line 131
[#10] *InternalDriverWrapper*->cancel in /code/vendor/amphp/amp/lib/Loop.php on line 305
[#11] Amp\Loop::cancel in /code/vendor/amphp/byte-stream/lib/ResourceInputStream.php on line 201
[#12] Amp\ByteStream\ResourceInputStream->free in /code/vendor/amphp/byte-stream/lib/ResourceInputStream.php on line 182
[#13] Amp\ByteStream\ResourceInputStream->close in /code/vendor/amphp/socket/src/ResourceSocket.php on line 166
[#14] Amp\Socket\ResourceSocket->close in /code/vendor/amphp/mysql/src/Internal/Processor.php on line 1238
[#15] Amp\Mysql\Internal\Processor->close in /code/vendor/amphp/mysql/src/Internal/Processor.php on line 272
[#16] Amp\Mysql\Internal\Processor->read in ? on line ?
[#17] Generator->send in /code/vendor/amphp/amp/lib/Coroutine.php on line 118
[#18] Amp\Coroutine->Amp\{closure} in /code/vendor/amphp/amp/lib/Internal/Placeholder.php on line 149
[#19] Amp\Promise@anonymous/code/vendor/amphp/amp/lib/Deferred.php:22$1631->resolve in /code/vendor/amphp/amp/lib/Deferred.php on line 53
[#20] Amp\Deferred->resolve in /code/vendor/amphp/byte-stream/lib/ResourceInputStream.php on line 198
[#21] Amp\ByteStream\ResourceInputStream->free in /code/vendor/amphp/byte-stream/lib/ResourceInputStream.php on line 182
[#22] Amp\ByteStream\ResourceInputStream->close in /code/vendor/amphp/socket/src/ResourceSocket.php on line 166
[#23] Amp\Socket\ResourceSocket->close in /code/vendor/amphp/mysql/src/Internal/Processor.php on line 1238
[#24] Amp\Mysql\Internal\Processor->close in /code/vendor/amphp/mysql/src/Internal/Processor.php on line 168
[#25] Amp\Mysql\Internal\Processor->Amp\Mysql\Internal\{closure} in /code/vendor/amphp/mysql/src/Internal/Processor.php on line 314
[#26] Amp\Mysql\Internal\Processor->appendTask in /code/vendor/amphp/mysql/src/Internal/Processor.php on line 169
[#27] Amp\Mysql\Internal\Processor->unreference in /code/vendor/amphp/mysql/src/Connection.php on line 207
[#28] Amp\Mysql\Connection->__destruct in /code/vendor/amphp/amp/lib/Loop/EventDriver.php on line 169
[#29] Amp\Loop\EventDriver->__destruct in ? on line ?
```

This sparked an investigation by us:
- This did only happen after we moved the service from PHP7.4.22 to PHP8.0.9
- It only happens together with the `Amp\Mysql\Connection::__destruct`
- When looking at the stacktrace, something is really strange:
  - Trace/29: Destructor is called normally
  - Trace/28: Somehow `Event::del` triggers a follow-up destruct of `Amp\Mysql\Connection`.
    *This does not make sense*: The method call should only free `libevent` resources and does not decrease any zendval refcount. I don't understand how the destructor gets triggered. [Link to the ext-event impl](https://bitbucket.org/osmanov/pecl-event/src/1fa696a0dc145d5d5f40a144f7a27be31eaf14a5/php8/classes/event.c#lines-280:294)

    If it were triggered by the `$this->events = []`, it would both be a different line-reference and also not happen. Destructs coming from resetting an array, come after the array is reset. That would avoid the error
   - Since the driver is statically available through `Loop::*`, the Mysql destructor can re-enter The to-be-destructed `EventDriver` object and lead to the error.

Therefore: We can't really explain why it's happening, but the proposed fix works in production and does not impact the implementation in anyother (negative) way.
