### PR TITLE
Fix EventDriver

### DIFF
--- a/lib/Loop/EventDriver.php
+++ b/lib/Loop/EventDriver.php
@@ -40,7 +40,9 @@ class EventDriver extends Driver
     public function __construct()
     {
         $config = new \EventConfig();
-        $config->requireFeatures(\EventConfig::FEATURE_FDS);
+        if (\DIRECTORY_SEPARATOR !== '\\') {
+            $config->requireFeatures(\EventConfig::FEATURE_FDS);
+        }
 
         $this->handle = new \EventBase($config);
         $this->nowOffset = getCurrentTime();

--- a/lib/Loop/EventDriver.php
+++ b/lib/Loop/EventDriver.php
@@ -39,8 +39,10 @@ class EventDriver extends Driver
 
     public function __construct()
     {
-        /** @psalm-suppress TooFewArguments https://github.com/JetBrains/phpstorm-stubs/pull/763 */
-        $this->handle = new \EventBase;
+        $config = new \EventConfig();
+        $config->requireFeatures(\EventConfig::FEATURE_FDS);
+
+        $this->handle = new \EventBase($config);
         $this->nowOffset = getCurrentTime();
         $this->now = \random_int(0, $this->nowOffset);
         $this->nowOffset -= $this->now;


### PR DESCRIPTION
I'm getting this error:

![Screenshot from 2021-09-06 15-27-13](https://user-images.githubusercontent.com/539462/132225394-f9adcdb9-24b1-4fa6-a3a1-feab5bf35538.png)

While googling I found this was previously reported to ReactPHP [here](https://github.com/reactphp/event-loop/issues/171) and they solved it [here](https://github.com/reactphp/event-loop/pull/156) and later on changed it [here](https://github.com/reactphp/event-loop/pull/205) to not use it on Windows. So I copied it into Amphp and it indeed helped. That said I have no clue what it's about, I just know it fixed the bug for me. Of course it's another random issue I can't provide a reproducer for. But considering that React is still using this, it should be safe I think.