### PR TITLE
Fix ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - "master"
+      - "v3"
+      - "v3-revolt"
 
 jobs:
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: Continuous Integration
 
 on:
-  - push
-  - pull_request
+  pull_request:
+  push:
+    branches:
+      - "master"
 
 jobs:
   tests:


### PR DESCRIPTION
This is the reason why https://github.com/amphp/amp/pull/360 seems to be "hanging". It's because your CI configuration is kinda wrong - starting checks on both PRs and all branches means it's triggered twice. Which works on your own PRs (you just see double the checks) but breaks for cross-fork PRs. I think it expects the push checks to happen for the branch but they don't because it's on another fork.

I'm sadly not an expert on this matter but I saw it several times in the past already. Basically no cross-fork PR can ever get a success with this setup.

The common setup I see around is this:

```
on:
  pull_request:
  push:
    branches:
      - "master"
```

Basically run checks only on PRs and master. In your case I think it would be master, v3, and v3-revolt - basically all branches that are expected to be merged into / used as base branches for PRs.