### PR TITLE
Allow completing a Future with another Future

### DIFF
--- a/lib/Deferred.php
+++ b/lib/Deferred.php
@@ -20,13 +20,13 @@ final class Deferred
     }
 
     /**
-     * Completes the operation with a result value.
+     * Resolves the operation with a result value or another Future.
      *
-     * @param T $result Result of the operation.
+     * @param T|Future<T> $result Result of the operation.
      */
-    public function complete(mixed $result = null): void
+    public function resolve(mixed $result = null): void
     {
-        $this->state->complete($result);
+        $this->state->resolve($result);
     }
 
     /**
@@ -42,9 +42,9 @@ final class Deferred
     /**
      * @return bool True if the operation has completed.
      */
-    public function isComplete(): bool
+    public function isResolved(): bool
     {
-        return $this->state->isComplete();
+        return $this->state->isResolved();
     }
 
     /**

--- a/lib/Future.php
+++ b/lib/Future.php
@@ -99,11 +99,11 @@ final class Future
     }
 
     /**
-     * @return bool True if the operation has completed.
+     * @return bool True if the operation has settled (completed or errored).
      */
-    public function isComplete(): bool
+    public function isSettled(): bool
     {
-        return $this->state->isComplete();
+        return $this->state->isSettled();
     }
 
     /**

--- a/lib/Internal/FutureIterator.php
+++ b/lib/Internal/FutureIterator.php
@@ -84,7 +84,7 @@ final class FutureIterator
             throw new \Error('Iterator has already been marked as complete');
         }
 
-        $this->complete = Future::complete();
+        $this->complete = Future::resolve();
 
         if (!$this->queue->pending && $this->queue->suspension) {
             $this->queue->suspension->resume(null);

--- a/lib/Internal/FutureState.php
+++ b/lib/Internal/FutureState.php
@@ -78,11 +78,11 @@ final class FutureState
     }
 
     /**
-     * Completes the operation with a result value.
+     * Resolves the operation with a result value or another Future.
      *
      * @param T $result Result of the operation.
      */
-    public function complete(mixed $result): void
+    public function resolve(mixed $result): void
     {
         if ($this->complete) {
             throw new \Error('Operation is no longer pending');
@@ -126,7 +126,7 @@ final class FutureState
     /**
      * @return bool True if the operation has completed.
      */
-    public function isComplete(): bool
+    public function isResolved(): bool
     {
         return $this->complete;
     }
@@ -134,9 +134,9 @@ final class FutureState
     /**
      * @return bool
      */
-    public function isSettled(): bool
+    public function isPending(): bool
     {
-        return $this->callbacks === null;
+        return $this->callbacks !== null;
     }
 
     /**

--- a/lib/Internal/functions.php
+++ b/lib/Internal/functions.php
@@ -11,7 +11,7 @@ namespace Amp\Internal;
 function run(FutureState $state, callable $callback): void
 {
     try {
-        $state->complete($callback());
+        $state->resolve($callback());
     } catch (\Throwable $exception) {
         $state->error($exception);
     }

--- a/test/Future/AllTest.php
+++ b/test/Future/AllTest.php
@@ -13,30 +13,30 @@ class AllTest extends TestCase
 {
     public function testSingleComplete(): void
     {
-        self::assertSame([42], all([Future::complete(42)]));
+        self::assertSame([42], all([Future::resolve(42)]));
     }
 
     public function testTwoComplete(): void
     {
-        self::assertSame([1, 2], all([Future::complete(1), Future::complete(2)]));
+        self::assertSame([1, 2], all([Future::resolve(1), Future::resolve(2)]));
     }
 
     public function testTwoFirstPending(): void
     {
         $deferred = new Deferred;
 
-        EventLoop::delay(0.01, fn () => $deferred->complete(1));
+        EventLoop::delay(0.01, fn () => $deferred->resolve(1));
 
-        self::assertSame([1 => 2, 0 => 1], all([$deferred->getFuture(), Future::complete(2)]));
+        self::assertSame([1 => 2, 0 => 1], all([$deferred->getFuture(), Future::resolve(2)]));
     }
 
     public function testArrayDestructuring(): void
     {
         $deferred = new Deferred;
 
-        EventLoop::delay(0.01, fn () => $deferred->complete(1));
+        EventLoop::delay(0.01, fn () => $deferred->resolve(1));
 
-        [$first, $second] = all([$deferred->getFuture(), Future::complete(2)]);
+        [$first, $second] = all([$deferred->getFuture(), Future::resolve(2)]);
 
         self::assertSame(1, $first);
         self::assertSame(2, $second);
@@ -47,7 +47,7 @@ class AllTest extends TestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('foo');
 
-        all([Future::error(new \Exception('foo')), Future::complete(2)]);
+        all([Future::error(new \Exception('foo')), Future::resolve(2)]);
     }
 
     public function testTwoThrowingWithOneLater(): void
@@ -68,7 +68,7 @@ class AllTest extends TestCase
 
         all((static function () {
             yield Future::error(new \Exception('foo'));
-            yield Future::complete(2);
+            yield Future::resolve(2);
         })());
     }
 
@@ -77,7 +77,7 @@ class AllTest extends TestCase
         $this->expectException(CancelledException::class);
         $deferreds = \array_map(function (int $value) {
             $deferred = new Deferred;
-            EventLoop::delay($value / 10, fn () => $deferred->complete($value));
+            EventLoop::delay($value / 10, fn () => $deferred->resolve($value));
             return $deferred;
         }, \range(1, 3));
 
@@ -91,7 +91,7 @@ class AllTest extends TestCase
     {
         $deferreds = \array_map(function (int $value) {
             $deferred = new Deferred;
-            EventLoop::delay($value / 10, fn () => $deferred->complete($value));
+            EventLoop::delay($value / 10, fn () => $deferred->resolve($value));
             return $deferred;
         }, \range(1, 3));
 

--- a/test/Future/AnyTest.php
+++ b/test/Future/AnyTest.php
@@ -14,24 +14,24 @@ class AnyTest extends TestCase
 {
     public function testSingleComplete(): void
     {
-        self::assertSame(42, any([Future::complete(42)]));
+        self::assertSame(42, any([Future::resolve(42)]));
     }
 
     public function testTwoComplete(): void
     {
-        self::assertSame(1, any([Future::complete(1), Future::complete(2)]));
+        self::assertSame(1, any([Future::resolve(1), Future::resolve(2)]));
     }
 
     public function testTwoFirstPending(): void
     {
         $deferred = new Deferred();
 
-        self::assertSame(2, any([$deferred->getFuture(), Future::complete(2)]));
+        self::assertSame(2, any([$deferred->getFuture(), Future::resolve(2)]));
     }
 
     public function testTwoFirstThrowing(): void
     {
-        self::assertSame(2, any([Future::error(new \Exception('foo')), Future::complete(2)]));
+        self::assertSame(2, any([Future::error(new \Exception('foo')), Future::resolve(2)]));
     }
 
     public function testTwoBothThrowing(): void
@@ -46,7 +46,7 @@ class AnyTest extends TestCase
     {
         self::assertSame(2, any((static function () {
             yield Future::error(new \Exception('foo'));
-            yield Future::complete(2);
+            yield Future::resolve(2);
         })()));
     }
 
@@ -55,7 +55,7 @@ class AnyTest extends TestCase
         $this->expectException(CancelledException::class);
         $deferreds = \array_map(function (int $value) {
             $deferred = new Deferred;
-            EventLoop::delay($value / 10, fn () => $deferred->complete($value));
+            EventLoop::delay($value / 10, fn () => $deferred->resolve($value));
             return $deferred;
         }, \range(1, 3));
 
@@ -69,7 +69,7 @@ class AnyTest extends TestCase
     {
         $deferreds = \array_map(function (int $value) {
             $deferred = new Deferred;
-            EventLoop::delay($value / 10, fn () => $deferred->complete($value));
+            EventLoop::delay($value / 10, fn () => $deferred->resolve($value));
             return $deferred;
         }, \range(1, 3));
 

--- a/test/Future/FutureTest.php
+++ b/test/Future/FutureTest.php
@@ -55,7 +55,7 @@ class FutureTest extends AsyncTestCase
         $deferred = new Deferred;
         $future = $deferred->getFuture();
 
-        $deferred->complete('result');
+        $deferred->resolve('result');
 
         self::assertSame('result', $future->await());
     }
@@ -65,14 +65,14 @@ class FutureTest extends AsyncTestCase
         $deferred = new Deferred;
         $future = $deferred->getFuture();
 
-        EventLoop::delay(0.01, fn () => $deferred->complete('result'));
+        EventLoop::delay(0.01, fn () => $deferred->resolve('result'));
 
         self::assertSame('result', $future->await());
     }
 
     public function testCompleteImmediate(): void
     {
-        $future = Future::complete('result');
+        $future = Future::resolve('result');
 
         self::assertSame('result', $future->await());
     }
@@ -143,7 +143,7 @@ class FutureTest extends AsyncTestCase
             self::assertSame(1, $future->await($source->getToken()));
         });
 
-        $deferred->complete(1);
+        $deferred->resolve(1);
         $source->cancel();
     }
 
@@ -209,9 +209,9 @@ class FutureTest extends AsyncTestCase
     {
         $deferred = new Deferred();
         $future = $deferred->getFuture();
-        $deferred->complete(Future::complete(1));
-        self::assertTrue($deferred->isComplete());
-        self::assertFalse($future->isSettled());
+        $deferred->resolve(Future::resolve(1));
+        self::assertTrue($deferred->isResolved());
+        self::assertFalse($future->isPending());
         self::assertSame(1, $future->await());
     }
 
@@ -219,8 +219,8 @@ class FutureTest extends AsyncTestCase
     {
         $exception = new TestException();
         $deferred = new Deferred();
-        $deferred->complete(Future::error($exception));
-        self::assertTrue($deferred->isComplete());
+        $deferred->resolve(Future::error($exception));
+        self::assertTrue($deferred->isResolved());
         $this->expectExceptionObject($exception);
         $deferred->getFuture()->await();
     }
@@ -234,15 +234,15 @@ class FutureTest extends AsyncTestCase
         $deferred2 = new Deferred();
         $future2 = $deferred2->getFuture();
 
-        $deferred1->complete($deferred2->getFuture());
+        $deferred1->resolve($deferred2->getFuture());
 
-        self::assertTrue($deferred1->isComplete());
-        self::assertFalse($deferred2->isComplete());
+        self::assertTrue($deferred1->isResolved());
+        self::assertFalse($deferred2->isResolved());
 
-        self::assertFalse($future1->isSettled());
-        self::assertFalse($future2->isSettled());
+        self::assertFalse($future1->isPending());
+        self::assertFalse($future2->isPending());
 
-        EventLoop::delay(0.1, static fn () => $deferred2->complete(1));
+        EventLoop::delay(0.1, static fn () => $deferred2->resolve(1));
 
         self::assertSame(1, $deferred2->getFuture()->await());
     }

--- a/test/Future/RaceTest.php
+++ b/test/Future/RaceTest.php
@@ -13,19 +13,19 @@ class RaceTest extends TestCase
 {
     public function testSingleComplete(): void
     {
-        self::assertSame(42, race([Future::complete(42)]));
+        self::assertSame(42, race([Future::resolve(42)]));
     }
 
     public function testTwoComplete(): void
     {
-        self::assertSame(1, Future\race([Future::complete(1), Future::complete(2)]));
+        self::assertSame(1, Future\race([Future::resolve(1), Future::resolve(2)]));
     }
 
     public function testTwoFirstPending(): void
     {
         $deferred = new Deferred;
 
-        self::assertSame(2, Future\race([$deferred->getFuture(), Future::complete(2)]));
+        self::assertSame(2, Future\race([$deferred->getFuture(), Future::resolve(2)]));
     }
 
     public function testTwoFirstThrowing(): void
@@ -33,7 +33,7 @@ class RaceTest extends TestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('foo');
 
-        race([Future::error(new \Exception('foo')), Future::complete(2)]);
+        race([Future::error(new \Exception('foo')), Future::resolve(2)]);
     }
 
     public function testTwoGeneratorThrows(): void
@@ -43,7 +43,7 @@ class RaceTest extends TestCase
 
         race((static function () {
             yield Future::error(new \Exception('foo'));
-            yield Future::complete(2);
+            yield Future::resolve(2);
         })());
     }
 
@@ -53,7 +53,7 @@ class RaceTest extends TestCase
 
         $deferreds = \array_map(function (int $value) {
             $deferred = new Deferred;
-            EventLoop::delay($value / 10, fn () => $deferred->complete($value));
+            EventLoop::delay($value / 10, fn () => $deferred->resolve($value));
             return $deferred;
         }, \range(1, 3));
 
@@ -67,7 +67,7 @@ class RaceTest extends TestCase
     {
         $deferreds = \array_map(function (int $value) {
             $deferred = new Deferred;
-            EventLoop::delay($value / 10, fn () => $deferred->complete($value));
+            EventLoop::delay($value / 10, fn () => $deferred->resolve($value));
             return $deferred;
         }, \range(1, 3));
 

--- a/test/Future/SettleTest.php
+++ b/test/Future/SettleTest.php
@@ -13,12 +13,12 @@ class SettleTest extends TestCase
 {
     public function testSingleComplete(): void
     {
-        self::assertSame([[], [42]], settle([Future::complete(42)]));
+        self::assertSame([[], [42]], settle([Future::resolve(42)]));
     }
 
     public function testTwoComplete(): void
     {
-        self::assertSame([[], [1, 2]], settle([Future::complete(1), Future::complete(2)]));
+        self::assertSame([[], [1, 2]], settle([Future::resolve(1), Future::resolve(2)]));
     }
 
     public function testTwoFirstThrowing(): void
@@ -26,7 +26,7 @@ class SettleTest extends TestCase
         $exception = new \Exception('foo');
         self::assertSame(
             [['one' => $exception], ['two' => 2]],
-            settle(['one' => Future::error($exception), 'two' => Future::complete(2)])
+            settle(['one' => Future::error($exception), 'two' => Future::resolve(2)])
         );
     }
 
@@ -42,7 +42,7 @@ class SettleTest extends TestCase
         $exception = new \Exception('foo');
         self::assertSame([[0 => $exception], [1 => 2]], settle((static function () use ($exception) {
             yield Future::error($exception);
-            yield Future::complete(2);
+            yield Future::resolve(2);
         })()));
     }
 
@@ -51,7 +51,7 @@ class SettleTest extends TestCase
         $this->expectException(CancelledException::class);
         $deferreds = \array_map(function (int $value) {
             $deferred = new Deferred;
-            EventLoop::delay($value / 10, fn () => $deferred->complete($value));
+            EventLoop::delay($value / 10, fn () => $deferred->resolve($value));
             return $deferred;
         }, \range(1, 3));
 
@@ -65,7 +65,7 @@ class SettleTest extends TestCase
     {
         $deferreds = \array_map(function (int $value) {
             $deferred = new Deferred;
-            EventLoop::delay($value / 10, fn () => $deferred->complete($value));
+            EventLoop::delay($value / 10, fn () => $deferred->resolve($value));
             return $deferred;
         }, \range(1, 3));
 

--- a/test/Future/SomeTest.php
+++ b/test/Future/SomeTest.php
@@ -14,24 +14,24 @@ class SomeTest extends TestCase
 {
     public function testSingleComplete(): void
     {
-        self::assertSame([0 => 42], some([Future::complete(42)], 1));
+        self::assertSame([0 => 42], some([Future::resolve(42)], 1));
     }
 
     public function testTwoComplete(): void
     {
-        self::assertSame([1, 2], some([Future::complete(1), Future::complete(2)], 2));
+        self::assertSame([1, 2], some([Future::resolve(1), Future::resolve(2)], 2));
     }
 
     public function testTwoFirstPending(): void
     {
         $deferred = new Deferred();
 
-        self::assertSame([1 => 2], some([$deferred->getFuture(), Future::complete(2)], 1));
+        self::assertSame([1 => 2], some([$deferred->getFuture(), Future::resolve(2)], 1));
     }
 
     public function testTwoFirstThrowing(): void
     {
-        self::assertSame(['two' => 2], some(['one' => Future::error(new \Exception('foo')), 'two' => Future::complete(2)], 1));
+        self::assertSame(['two' => 2], some(['one' => Future::error(new \Exception('foo')), 'two' => Future::resolve(2)], 1));
     }
 
     public function testTwoBothThrowing(): void
@@ -46,7 +46,7 @@ class SomeTest extends TestCase
     {
         self::assertSame([1 => 2], some((static function () {
             yield Future::error(new \Exception('foo'));
-            yield Future::complete(2);
+            yield Future::resolve(2);
         })(), 1));
     }
 
@@ -55,7 +55,7 @@ class SomeTest extends TestCase
         $this->expectException(CancelledException::class);
         $deferreds = \array_map(function (int $value) {
             $deferred = new Deferred;
-            EventLoop::delay($value / 10, fn () => $deferred->complete($value));
+            EventLoop::delay($value / 10, fn () => $deferred->resolve($value));
             return $deferred;
         }, \range(1, 3));
 
@@ -69,7 +69,7 @@ class SomeTest extends TestCase
     {
         $deferreds = \array_map(function (int $value) {
             $deferred = new Deferred;
-            EventLoop::delay($value / 10, fn () => $deferred->complete($value));
+            EventLoop::delay($value / 10, fn () => $deferred->resolve($value));
             return $deferred;
         }, \range(1, 3));
 
@@ -90,6 +90,6 @@ class SomeTest extends TestCase
     {
         $this->expectException(\Error::class);
         $this->expectExceptionMessage('required count');
-        some([Future::complete(1), Future::complete(2)], 3);
+        some([Future::resolve(1), Future::resolve(2)], 3);
     }
 }

--- a/test/FutureTest.php
+++ b/test/FutureTest.php
@@ -10,15 +10,15 @@ class FutureTest extends AsyncTestCase
 {
     public function testApplyWithCompleteFuture(): void
     {
-        $future = Future::complete(1);
+        $future = Future::resolve(1);
         $future = $future->apply(static fn (int $value) => $value + 1);
         self::assertSame(2, $future->await());
     }
 
     public function testApplyWithSuspendInCallback(): void
     {
-        $future = Future::complete(1);
-        $future = $future->apply(static fn (int $value) => $value + Future::complete(1)->await());
+        $future = Future::resolve(1);
+        $future = $future->apply(static fn (int $value) => $value + Future::resolve(1)->await());
         self::assertSame(2, $future->await());
     }
     public function testApplyWithPendingFuture(): void
@@ -28,7 +28,7 @@ class FutureTest extends AsyncTestCase
         $future = $deferred->getFuture();
         $future = $future->apply(static fn (int $value) => $value + 1);
 
-        EventLoop::delay(0.1, static fn () => $deferred->complete(1));
+        EventLoop::delay(0.1, static fn () => $deferred->resolve(1));
 
         self::assertSame(2, $future->await());
     }
@@ -44,7 +44,7 @@ class FutureTest extends AsyncTestCase
     public function testApplyWithThrowingCallback(): void
     {
         $exception = new TestException();
-        $future = Future::complete(1);
+        $future = Future::resolve(1);
         $future = $future->apply(static fn () => throw $exception);
         $this->expectExceptionObject($exception);
         $future->await();
@@ -52,7 +52,7 @@ class FutureTest extends AsyncTestCase
 
     public function testCatchWithCompleteFuture(): void
     {
-        $future = Future::complete(1);
+        $future = Future::resolve(1);
         $future = $future->catch($this->createCallback(0));
         self::assertSame(1, $future->await());
     }
@@ -60,7 +60,7 @@ class FutureTest extends AsyncTestCase
     public function testCatchWithSuspendInCallback(): void
     {
         $future = Future::error(new TestException());
-        $future = $future->catch(static fn (\Throwable $exception) => Future::complete(1)->await());
+        $future = $future->catch(static fn (\Throwable $exception) => Future::resolve(1)->await());
         self::assertSame(1, $future->await());
     }
     public function testCatchWithPendingFuture(): void
@@ -86,7 +86,7 @@ class FutureTest extends AsyncTestCase
 
     public function testFinallyWithCompleteFuture(): void
     {
-        $future = Future::complete(1);
+        $future = Future::resolve(1);
         $future = $future->finally($this->createCallback(1));
         self::assertSame(1, $future->await());
     }
@@ -102,8 +102,8 @@ class FutureTest extends AsyncTestCase
 
     public function testFinallyWithSuspendInCallback(): void
     {
-        $future = Future::complete(1);
-        $future = $future->finally(static fn () => Future::complete()->await());
+        $future = Future::resolve(1);
+        $future = $future->finally(static fn () => Future::resolve()->await());
         self::assertSame(1, $future->await());
     }
     public function testFinallyWithPendingFuture(): void
@@ -113,7 +113,7 @@ class FutureTest extends AsyncTestCase
         $future = $deferred->getFuture();
         $future = $future->finally($this->createCallback(1));
 
-        EventLoop::delay(0.1, static fn () => $deferred->complete(1));
+        EventLoop::delay(0.1, static fn () => $deferred->resolve(1));
 
         self::assertSame(1, $future->await());
     }
@@ -121,7 +121,7 @@ class FutureTest extends AsyncTestCase
     public function testFinallyWithThrowingCallback(): void
     {
         $exception = new TestException();
-        $future = Future::complete(1);
+        $future = Future::resolve(1);
         $future = $future->finally(static fn () => throw $exception);
         $this->expectExceptionObject($exception);
         $future->await();


### PR DESCRIPTION
Not sure about the current terminology:
- Complete means `Deferred::complete()` or `Deferred::error()` has been invoked.
- Settled means the operation has resulted in a value or exception and settled the future.

So a future becomes settled, and a deferred is completed, either with a value, a future, or an exception.

