### PR TITLE
Future and Defered's complete() should have default value to null

### DIFF
--- a/lib/Deferred.php
+++ b/lib/Deferred.php
@@ -24,7 +24,7 @@ final class Deferred
      *
      * @param T $result Result of the operation.
      */
-    public function complete(mixed $result=null): void
+    public function complete(mixed $result = null): void
     {
         $this->state->complete($result);
     }

--- a/lib/Deferred.php
+++ b/lib/Deferred.php
@@ -24,7 +24,7 @@ final class Deferred
      *
      * @param T $result Result of the operation.
      */
-    public function complete(mixed $result): void
+    public function complete(mixed $result=null): void
     {
         $this->state->complete($result);
     }

--- a/lib/Future.php
+++ b/lib/Future.php
@@ -65,7 +65,7 @@ final class Future
      *
      * @return Future<Tv>
      */
-    public static function complete(mixed $result=null): self
+    public static function complete(mixed $result = null): self
     {
         $state = new FutureState();
         $state->complete($result);

--- a/lib/Future.php
+++ b/lib/Future.php
@@ -65,7 +65,7 @@ final class Future
      *
      * @return Future<Tv>
      */
-    public static function complete(mixed $result): self
+    public static function complete(mixed $result=null): self
     {
         $state = new FutureState();
         $state->complete($result);

--- a/lib/Internal/FutureIterator.php
+++ b/lib/Internal/FutureIterator.php
@@ -84,7 +84,7 @@ final class FutureIterator
             throw new \Error('Iterator has already been marked as complete');
         }
 
-        $this->complete = Future::complete(null);
+        $this->complete = Future::complete();
 
         if (!$this->queue->pending && $this->queue->suspension) {
             $this->queue->suspension->resume(null);

--- a/test/Future/FutureTest.php
+++ b/test/Future/FutureTest.php
@@ -120,7 +120,7 @@ class FutureTest extends AsyncTestCase
         $this->expectException(\Error::class);
         $this->expectExceptionMessage('Cannot complete with an instance of');
 
-        $deferred->complete(Future::complete(null));
+        $deferred->complete(Future::complete());
     }
 
     public function testCancellation(): void

--- a/test/FutureTest.php
+++ b/test/FutureTest.php
@@ -103,7 +103,7 @@ class FutureTest extends AsyncTestCase
     public function testFinallyWithSuspendInCallback(): void
     {
         $future = Future::complete(1);
-        $future = $future->finally(static fn () => Future::complete(null)->await());
+        $future = $future->finally(static fn () => Future::complete()->await());
         self::assertSame(1, $future->await());
     }
     public function testFinallyWithPendingFuture(): void


### PR DESCRIPTION
Sometimes we just need resolve state, don't need any return value.

https://github.com/amphp/amp/issues/364
https://github.com/amphp/amp/pull/367
