### PR TITLE
Cancel DeferredCancellation when destroyed

### DIFF
--- a/src/DeferredCancellation.php
+++ b/src/DeferredCancellation.php
@@ -46,9 +46,19 @@ final class DeferredCancellation
         $this->cancellation = new Internal\WrappedCancellation($this->source);
     }
 
+    public function __destruct()
+    {
+        $this->source->cancel();
+    }
+
     public function getCancellation(): Cancellation
     {
         return $this->cancellation;
+    }
+
+    public function isCancelled(): bool
+    {
+        return $this->source->isRequested();
     }
 
     /**

--- a/test/Cancellation/CancellationTest.php
+++ b/test/Cancellation/CancellationTest.php
@@ -24,7 +24,11 @@ class CancellationTest extends AsyncTestCase
 
         $deferredCancellation->getCancellation()->unsubscribe($id);
 
+        self::assertFalse($deferredCancellation->isCancelled());
+
         $deferredCancellation->cancel();
+
+        self::assertTrue($deferredCancellation->isCancelled());
     }
 
     public function testThrowingCallbacksEndUpInLoop(): void
@@ -59,5 +63,12 @@ class CancellationTest extends AsyncTestCase
         $cancellationSource = new DeferredCancellation;
         $cancellationSource->cancel();
         $cancellationSource->getCancellation()->subscribe($this->createCallback(1));
+    }
+
+    public function testCancelOnDestruct(): void
+    {
+        $cancellationSource = new DeferredCancellation;
+        $cancellationSource->getCancellation()->subscribe($this->createCallback(1));
+        unset($cancellationSource);
     }
 }


### PR DESCRIPTION
This will automatically cancel the associated `Cancellation` when the `DeferredCancellation` object is destroyed.

An exception object is only created when needed to avoid creating a backtrace on the normal case when the object is destroyed after all listeners have unsubscribed because the operation completed.

Related to issue #381.