### PR TITLE
Fixed memory leak in CombinedCancellationToken

### DIFF
--- a/test/CombinedCancellationTokenTest.php
+++ b/test/CombinedCancellationTokenTest.php
@@ -33,7 +33,7 @@ class CombinedCancellationTokenTest extends BaseTest
             if ($firstMemoryMeasure > 0) {
                 self::assertEquals($firstMemoryMeasure, memory_get_usage(true));
             }
-            print "Memory: " . (memory_get_usage(true) / 1000) . PHP_EOL;
+            // print "Memory: " . (memory_get_usage(true) / 1000) . PHP_EOL;
         }
     }
 }

--- a/test/CombinedCancellationTokenTest.php
+++ b/test/CombinedCancellationTokenTest.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Amp\Test;
+
+use Amp\CancellationTokenSource;
+use Amp\CombinedCancellationToken;
+
+class CombinedCancellationTokenTest extends BaseTest
+{
+    private const LOOP_COUNT = 20;
+    private const TOKENS_COUNT = 1000;
+
+    public function testBenchmark(): void
+    {
+        $firstMemoryMeasure = 0;
+
+        for ($i = 0; $i < self::LOOP_COUNT; $i++) {
+            $tokens = [];
+            for ($j = 0; $j < self::TOKENS_COUNT; $j++) {
+                $tokens[] = (new CancellationTokenSource)->getToken();
+            }
+            $combinedToken = new CombinedCancellationToken(...$tokens);
+
+            if (!$firstMemoryMeasure && $i > self::LOOP_COUNT / 2) {
+                // Warmup and store first memory usage after 50% of iterations
+                $firstMemoryMeasure = memory_get_usage(true);
+            }
+            // Remove tokens from memory
+            unset($combinedToken);
+
+            // Asserts
+            if ($firstMemoryMeasure > 0) {
+                self::assertEquals($firstMemoryMeasure, memory_get_usage(true));
+            }
+            print "Memory: " . (memory_get_usage(true) / 1000) . PHP_EOL;
+        }
+    }
+}

--- a/test/CombinedCancellationTokenTest.php
+++ b/test/CombinedCancellationTokenTest.php
@@ -24,16 +24,15 @@ class CombinedCancellationTokenTest extends BaseTest
 
             if (!$firstMemoryMeasure && $i > self::LOOP_COUNT / 2) {
                 // Warmup and store first memory usage after 50% of iterations
-                $firstMemoryMeasure = memory_get_usage(true);
+                $firstMemoryMeasure = \memory_get_usage(true);
             }
             // Remove tokens from memory
             unset($combinedToken);
 
             // Asserts
             if ($firstMemoryMeasure > 0) {
-                self::assertEquals($firstMemoryMeasure, memory_get_usage(true));
+                self::assertEquals($firstMemoryMeasure, \memory_get_usage(true));
             }
-            // print "Memory: " . (memory_get_usage(true) / 1000) . PHP_EOL;
         }
     }
 }


### PR DESCRIPTION
Many years ago there was a bug.
It was fixed in another repository, but in amp it still have a memory leak.

Original issue:
https://github.com/amphp/http-client/issues/157

Another old patch:
https://github.com/amphp/http-client/commit/e9d6739bcc04546539cbd8aa0cfa27879d6672b3

And now create fix. If you have idea how to create better test case - let me know.

Here is memory usage before:
```
Memory: 8388.608
Memory: 10485.76
Memory: 10485.76
Memory: 12582.912
Memory: 14680.064
Memory: 14680.064
Memory: 14680.064
Memory: 14680.064
Memory: 14680.064
Memory: 14680.064
```

Here is after:
```
Memory: 8388.608
Memory: 8388.608
Memory: 8388.608
Memory: 8388.608
Memory: 8388.608
Memory: 8388.608
Memory: 8388.608
Memory: 8388.608
Memory: 8388.608
Memory: 8388.608
```

Here is my script for http-client to reproduce a memory leak:

```
<?php
declare(strict_types=1);

require_once __DIR__ . '/../vendor/autoload.php';

use Amp\CancellationTokenSource;
use Amp\Http\Client\Connection\UnlimitedConnectionPool;
use Amp\Http\Client\HttpClientBuilder;
use Amp\Http\Client\Request;
use Amp\Loop;

function convert($size)
{
    $unit = array('b', 'kb', 'mb', 'gb', 'tb', 'pb');
    return @round($size / pow(1024, ($i = floor(log($size, 1024)))), 2) . ' ' . $unit[$i];
}

Loop::run(function () {

    $pool = new UnlimitedConnectionPool;

    $client = (new HttpClientBuilder)
        ->usingPool($pool)
        ->followRedirects(0)
        ->build();

    for ($i = 0; $i < 100; $i++) {
        $tokenSource = new CancellationTokenSource;
        $response = yield $client->request(new Request("http://httpbin.org/get"));
        echo convert(memory_get_usage(true))."\n";
    }
    gc_status();
});
```