### PR TITLE
Allow GC of arguments during `async()` closure execution

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -31,7 +31,8 @@ function async(\Closure $closure, mixed ...$args): Future
         $state = $closure = $args = null;
 
         try {
-            $s->complete($c(...$a));
+            // Clear $a to allow garbage collection
+            $s->complete($c(...$a, ...($a = [])));
         } catch (\Throwable $exception) {
             $s->error($exception);
         }

--- a/test/Future/FutureTest.php
+++ b/test/Future/FutureTest.php
@@ -344,6 +344,22 @@ class FutureTest extends AsyncTestCase
         $future->await();
     }
 
+    public function testAsyncExecutionDoesNotKeepReferenceToArgs(): void
+    {
+        $this->expectOutputString('123');
+
+        async(static function (object $object): void {
+            print 1;
+            unset($object);
+            print 3;
+        }, new class () {
+            public function __destruct()
+            {
+                print 2;
+            }
+        })->await();
+    }
+
     /**
      * @template T
      *


### PR DESCRIPTION
Allows users to free memory if an argument is no longer required.
Requires https://github.com/revoltphp/event-loop/pull/60. 