### PR TITLE
Declare incompatibility with revolt 0.1.x.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.1",
-        "revolt/event-loop": "^0.2 || ^0.1"
+        "revolt/event-loop": "^0.2"
     },
     "require-dev": {
         "ext-json": "*",


### PR DESCRIPTION
v3 is no longer compatible with `^0.1` because we rely on calls to `Revolt\EventLoop::getSuspension()` that does not exist in that version.