### PR TITLE
Track origin of unhandled futures

### DIFF
--- a/src/Future/UnhandledFutureError.php
+++ b/src/Future/UnhandledFutureError.php
@@ -7,11 +7,15 @@ namespace Amp\Future;
  */
 final class UnhandledFutureError extends \Error
 {
-    public function __construct(\Throwable $previous)
+    public function __construct(\Throwable $previous, ?string $origin = null)
     {
         $message = 'Unhandled future: ' . $previous::class . ': "' . $previous->getMessage()
             . '"; Await the Future with Future::await() before the future is destroyed or use '
-            . 'Future::ignore() to suppress this exception';
+            . 'Future::ignore() to suppress this exception.';
+
+        if ($origin) {
+            $message .= 'The future has been created at ' . $origin;
+        }
 
         parent::__construct($message, 0, $previous);
     }

--- a/src/Internal/FutureState.php
+++ b/src/Internal/FutureState.php
@@ -32,10 +32,25 @@ final class FutureState
 
     private ?\Throwable $throwable = null;
 
+    private ?string $creationTrace = null;
+
+    public function __construct()
+    {
+        \assert((function () {
+            if (isDebugEnabled()) {
+                $trace = \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS);
+                \array_shift($trace); // remove current closure
+                $this->creationTrace = formatStacktrace($trace);
+            }
+
+            return true;
+        })());
+    }
+
     public function __destruct()
     {
         if ($this->throwable && !$this->handled) {
-            $throwable = new UnhandledFutureError($this->throwable);
+            $throwable = new UnhandledFutureError($this->throwable, $this->creationTrace);
             EventLoop::queue(static fn () => throw $throwable);
         }
     }


### PR DESCRIPTION
Possible implementation for #404, but only with assertions enabled.