### PR TITLE
Use matrix.operating-system in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             php-version: '8.4'
             psalm: 'none'
 
-    name: PHP ${{ matrix.php-version }} on ${{ runner.os }}
+    name: PHP ${{ matrix.php-version }} on ${{ matrix.operating-system }}
 
     runs-on: ${{ matrix.operating-system }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,15 @@ jobs:
 
           - operating-system: 'windows-latest'
             php-version: '8.3'
-            job-description: 'on Windows'
 
           - operating-system: 'macos-latest'
             php-version: '8.3'
-            job-description: 'on macOS'
 
           - operating-system: 'ubuntu-latest'
             php-version: '8.4'
-            psalm: none
+            psalm: 'none'
 
-    name: PHP ${{ matrix.php-version }} ${{ matrix.job-description }}
+    name: PHP ${{ matrix.php-version }} on ${{ runner.os }}
 
     runs-on: ${{ matrix.operating-system }}
 


### PR DESCRIPTION
GHA has a built-in `runner.os` for human-friendly OS name.
