### PR TITLE
Add Interval

### DIFF
--- a/src/Interval.php
+++ b/src/Interval.php
@@ -10,7 +10,7 @@ use Revolt\EventLoop;
  */
 final class Interval
 {
-    private readonly string $watcher;
+    private readonly string $callbackId;
 
     /**
      * @param float $interval Invoke the function every $interval seconds.
@@ -20,16 +20,16 @@ final class Interval
      */
     public function __construct(float $interval, \Closure $closure, bool $reference = true)
     {
-        $this->watcher = EventLoop::repeat($interval, $closure);
+        $this->callbackId = EventLoop::repeat($interval, $closure);
 
         if (!$reference) {
-            EventLoop::unreference($this->watcher);
+            EventLoop::unreference($this->callbackId);
         }
     }
 
     public function __destruct()
     {
-        EventLoop::cancel($this->watcher);
+        EventLoop::cancel($this->callbackId);
     }
 
     /**
@@ -37,7 +37,7 @@ final class Interval
      */
     public function isReferenced(): bool
     {
-        return EventLoop::isReferenced($this->watcher);
+        return EventLoop::isReferenced($this->callbackId);
     }
 
     /**
@@ -47,7 +47,7 @@ final class Interval
      */
     public function reference(): self
     {
-        EventLoop::reference($this->watcher);
+        EventLoop::reference($this->callbackId);
 
         return $this;
     }
@@ -59,7 +59,7 @@ final class Interval
      */
     public function unreference(): self
     {
-        EventLoop::unreference($this->watcher);
+        EventLoop::unreference($this->callbackId);
 
         return $this;
     }
@@ -69,7 +69,7 @@ final class Interval
      */
     public function isEnabled(): bool
     {
-        return EventLoop::isEnabled($this->watcher);
+        return EventLoop::isEnabled($this->callbackId);
     }
 
     /**
@@ -79,7 +79,7 @@ final class Interval
      */
     public function enable(): self
     {
-        EventLoop::enable($this->watcher);
+        EventLoop::enable($this->callbackId);
 
         return $this;
     }
@@ -91,7 +91,7 @@ final class Interval
      */
     public function disable(): self
     {
-        EventLoop::disable($this->watcher);
+        EventLoop::disable($this->callbackId);
 
         return $this;
     }

--- a/src/Interval.php
+++ b/src/Interval.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types=1);
+
+namespace Amp;
+
+use Revolt\EventLoop;
+
+/**
+ * This object invokes the given callback within a new coroutine every $interval seconds until either the
+ * {@see self::disable()} method is called or the object is destroyed.
+ */
+final class Interval
+{
+    private readonly string $watcher;
+
+    /**
+     * @param float $interval Invoke the function every $interval seconds.
+     * @param \Closure():void $closure Use {@see weakClosure()} to avoid a circular reference if storing this object
+     *      as a property of another object.
+     * @param bool $reference If false, unreference the underlying watcher.
+     */
+    public function __construct(float $interval, \Closure $closure, bool $reference = true)
+    {
+        $this->watcher = EventLoop::repeat($interval, $closure);
+
+        if (!$reference) {
+            EventLoop::unreference($this->watcher);
+        }
+    }
+
+    public function __destruct()
+    {
+        EventLoop::cancel($this->watcher);
+    }
+
+    /**
+     * @return bool True if the internal watcher is referenced.
+     */
+    public function isReferenced(): bool
+    {
+        return EventLoop::isReferenced($this->watcher);
+    }
+
+    /**
+     * References the internal watcher in the event loop, keeping the loop running while the repeat loop is enabled.
+     *
+     * @return $this
+     */
+    public function reference(): self
+    {
+        EventLoop::reference($this->watcher);
+
+        return $this;
+    }
+
+    /**
+     * Unreferences the internal watcher in the event loop, allowing the loop to stop while the repeat loop is enabled.
+     *
+     * @return $this
+     */
+    public function unreference(): self
+    {
+        EventLoop::unreference($this->watcher);
+
+        return $this;
+    }
+
+    /**
+     * @return bool True if the repeating timer is enabled.
+     */
+    public function isEnabled(): bool
+    {
+        return EventLoop::isEnabled($this->watcher);
+    }
+
+    /**
+     * Restart the repeating timer if previously stopped with {@see self::disable()}.
+     *
+     * @return $this
+     */
+    public function enable(): self
+    {
+        EventLoop::enable($this->watcher);
+
+        return $this;
+    }
+
+    /**
+     * Stop the repeating timer. Restart it with {@see self::enable()}.
+     *
+     * @return $this
+     */
+    public function disable(): self
+    {
+        EventLoop::disable($this->watcher);
+
+        return $this;
+    }
+}

--- a/test/IntervalTest.php
+++ b/test/IntervalTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Amp;
+
+class IntervalTest extends TestCase
+{
+    public function testCancelWhenDestroyed(): void
+    {
+        $timeout = 0.01;
+        $invocationCount = 0;
+        $interval = new Interval($timeout, function () use (&$invocationCount): void {
+            ++$invocationCount;
+        });
+
+        delay($timeout * 1.5);
+
+        self::assertGreaterThan(0, $invocationCount);
+        $originalCount = $invocationCount;
+
+        unset($interval);
+
+        delay($timeout * 10);
+
+        self::assertSame($originalCount, $invocationCount);
+    }
+
+    public function testEnableAndDisable(): void
+    {
+        $timeout = 0.01;
+        $invocationCount = 0;
+        $interval = new Interval($timeout, function () use (&$invocationCount): void {
+            ++$invocationCount;
+        });
+
+        $interval->disable();
+        self::assertFalse($interval->isEnabled());
+
+        delay($timeout * 2);
+
+        self::assertSame(0, $invocationCount);
+
+        $interval->enable();
+        self::assertTrue($interval->isEnabled());
+
+        delay($timeout * 1.5);
+
+        self::assertSame(1, $invocationCount);
+    }
+}


### PR DESCRIPTION
This adds a utility class `Interval` which controls a repeating timer, automatically cancelling the timer when the object is destroyed.

The main use-case of this object is to store an instance of `Interval` as an object property. When the holding object is destroyed, the repeating timer will be cancelled. This avoids a bit of boilerplate in the class, such as needing to declare a destructor to manually cancel the event loop callback.

The value here isn't necessarily huge, but this is a pattern we frequently use for classes with self-cleanup mechanisms such as [`LocalCache`](https://github.com/amphp/cache/blob/46912e387e6aa94933b61ea1ead9cf7540b7797c/src/LocalCache.php).