### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,15 +235,15 @@ individual keys in the component array are preserved from the `iterable` passed 
 
 ##### awaitAll
 
-`Amp\Promise\awaitAll($iterable, $cancellation)` awaits all futures and returns their results as `[$errors, $values]` array.
+`Amp\Future\awaitAll($iterable, $cancellation)` awaits all futures and returns their results as `[$errors, $values]` array.
 
 ##### awaitFirst
 
-`Amp\Promise\awaitFirst($iterable, $cancellation)` unwraps the first completed `Future`, whether successfully completed or errored.
+`Amp\Future\awaitFirst($iterable, $cancellation)` unwraps the first completed `Future`, whether successfully completed or errored.
 
 ##### awaitAny
 
-`Amp\Promise\awaitAny($iterable, $cancellation)` unwraps the first successfully completed `Future`.
+`Amp\Future\awaitAny($iterable, $cancellation)` unwraps the first successfully completed `Future`.
 
 #### Future Creation
 


### PR DESCRIPTION
Changing references from Amp\Promise to Amp\Future for awaitAll, awaitFirst and awaitAny functions.