### PR TITLE
Add export-ignore rules to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@ phpunit.xml.dist export-ignore
 README.md export-ignore
 CONTRIBUTING.md export-ignore
 CHANGELOG.md export-ignore
+psalm.xml export-ignore


### PR DESCRIPTION
Current archive targets other than src/ will be as follows:
```bash
gh api repos/amphp/amp/tarball/HEAD | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -vE '^src/' | sort
```

```
composer.json
LICENSE
psalm.xml
```

With this PR, the archive targets other than src/ will be as follows:
```bash
gh api repos/sasezaki/amp/tarball/patch-gitattributes | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -vE '^src/' | sort
```

```
composer.json
LICENSE
```

Changes:
- Added `psalm.xml export-ignore`
  - `psalm.xml`: Psalm static analysis configuration; not needed by package consumers.
