### PR TITLE
Add Future completion subscriptions

### DIFF
--- a/src/Future.php
+++ b/src/Future.php
@@ -140,8 +140,8 @@ final class Future
     /**
      * Subscribes a callback to be invoked when this Future completes or errors.
      *
-     * The callback might be invoked immediately if this Future has already completed. The callback must not suspend.
-     * Any unhandled exceptions will be thrown into the event loop.
+     * The callback is always queued for execution on the event loop, even if this Future has already completed.
+     * The callback must not suspend. Any unhandled exceptions will be thrown into the event loop.
      *
      * @param \Closure(?\Throwable, mixed): void $callback Callback to be invoked on error or successful completion.
      *

--- a/src/Future.php
+++ b/src/Future.php
@@ -138,6 +138,31 @@ final class Future
     }
 
     /**
+     * Subscribes a callback to be invoked when this Future completes or errors.
+     *
+     * The callback might be invoked immediately if this Future has already completed. The callback must not suspend.
+     * Any unhandled exceptions will be thrown into the event loop.
+     *
+     * @param \Closure(?\Throwable, mixed): void $callback Callback to be invoked on error or successful completion.
+     *
+     * @return string Identifier that can be used to cancel the subscription.
+     */
+    public function subscribe(\Closure $callback): string
+    {
+        return $this->state->subscribe($callback);
+    }
+
+    /**
+     * Unsubscribes a previously registered callback.
+     *
+     * The callback might still be invoked if the Future has already completed.
+     */
+    public function unsubscribe(string $id): void
+    {
+        $this->state->unsubscribe($id);
+    }
+
+    /**
      * Attaches a callback that is invoked if this future completes. The returned future is completed with the return
      * value of the callback, or errors with an exception thrown from the callback.
      *

--- a/test/Future/FutureTest.php
+++ b/test/Future/FutureTest.php
@@ -323,6 +323,40 @@ class FutureTest extends TestCase
         $deferred->complete(1);
 
         delay(0); // tick event loop
+
+        self::assertSame(1, $future->await());
+    }
+
+    public function testUnsubscribeAfterCompletionDoesNotCancelQueuedCallback(): void
+    {
+        $called = false;
+        $future = Future::complete(1);
+        $id = $future->subscribe(static function () use (&$called): void {
+            $called = true;
+        });
+
+        $future->unsubscribe($id);
+        self::assertFalse($called);
+
+        delay(0); // tick event loop
+
+        self::assertTrue($called);
+    }
+
+    public function testThrowingSubscriptionCallbackEndsUpInEventLoop(): void
+    {
+        EventLoop::setErrorHandler(static function (\Throwable $exception) use (&$reason): void {
+            $reason = $exception;
+        });
+
+        Future::complete()->subscribe(static function (): void {
+            throw new \Exception('subscription callback failed');
+        });
+
+        delay(0); // tick event loop
+
+        self::assertInstanceOf(\Exception::class, $reason);
+        self::assertSame('subscription callback failed', $reason->getMessage());
     }
 
     public function testMapWithCompleteFuture(): void

--- a/test/Future/FutureTest.php
+++ b/test/Future/FutureTest.php
@@ -275,6 +275,56 @@ class FutureTest extends TestCase
         delay(0); // tick event loop
     }
 
+    public function testSubscribeWithCompletedFuture(): void
+    {
+        Future::complete(1)->subscribe(function (?\Throwable $error, mixed $value): void {
+            self::assertNull($error);
+            self::assertSame(1, $value);
+        });
+
+        delay(0); // tick event loop
+    }
+
+    public function testSubscribeWithErroredFuture(): void
+    {
+        $exception = new \Exception();
+
+        Future::error($exception)->subscribe(function (?\Throwable $error, mixed $value) use ($exception): void {
+            self::assertSame($exception, $error);
+            self::assertNull($value);
+        });
+
+        delay(0); // tick event loop
+    }
+
+    public function testSubscribeWithPendingFuture(): void
+    {
+        $deferred = new DeferredFuture;
+        $future = $deferred->getFuture();
+        $future->subscribe(function (?\Throwable $error, mixed $value): void {
+            self::assertNull($error);
+            self::assertSame(1, $value);
+        });
+
+        $deferred->complete(1);
+
+        delay(0); // tick event loop
+    }
+
+    public function testUnsubscribe(): void
+    {
+        $deferred = new DeferredFuture;
+        $future = $deferred->getFuture();
+        $id = $future->subscribe(function (): void {
+            self::fail('Callback has been called');
+        });
+
+        $future->unsubscribe($id);
+        $deferred->complete(1);
+
+        delay(0); // tick event loop
+    }
+
     public function testMapWithCompleteFuture(): void
     {
         $future = Future::complete(1);


### PR DESCRIPTION
## Context

Promise adapters may need to observe a Future completion without transforming it into another Future.

## Decision

Add `Future::subscribe()` and `Future::unsubscribe()` as public facades for the existing one-shot completion callback mechanism.

## Consequences

Adapters can observe values and errors without allocating derived Future chains. Callback subscriptions can be removed before a Future completes.

## Implementation Example

[GraphQL PHP PR #8](https://github.com/simPod/graphql-php/pull/8) uses `Future::subscribe()` to replace completion observation through `map()->catch()->ignore()`.

The chained approach creates two derived `FutureState` and `Future` pairs per observation. Direct subscription registers one callback on the original Future.

## Benchmark

The GraphQL PHP implementation was profiled with 500 parent objects and six Future-backed fields per parent. Both warmed profiles executed the same query and 9 SQL requests. Assertions were enabled and `AMP_DEBUG` was disabled.

| Observation strategy | Wall time | CPU time | Peak memory |
|---|---:|---:|---:|
| `map()->catch()->ignore()` | 5.61 s | 2.44 s | 180 MB |
| Direct subscription | 5.21 s | 1.81 s | 145 MB |

Direct subscription reduced CPU time by approximately 26% and peak memory by approximately 19% in this profile.

[View the Blackfire comparison](app.blackfire.io/profiles/compare/f4fce594-cbb7-492d-b2ca-fb0e01b8d2e2/8d217f7a-3ff8-46db-a616-96e61b6d7120/graph).

The direct variant used the same underlying completion subscription mechanism exposed by this PR. These measurements demonstrate the effect in the GraphQL PHP adapter and are not a general performance guarantee.